### PR TITLE
[SF-18] Rename prepublish hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "solhint:check": "solhint 'contracts/**/*.sol'",
     "prepare": "husky install",
     "ganache": "ganache",
-    "prepublishOnly": "npm run compile"
+    "prepublish": "npm run compile"
   },
   "author": "Secured Finance",
   "license": "ISC",


### PR DESCRIPTION
- Rename a npm script from `prepublishOnly` to `prepublish`