### PR TITLE
[SF-169] Add event for when order is filled

### DIFF
--- a/contracts/LendingMarketController.sol
+++ b/contracts/LendingMarketController.sol
@@ -301,6 +301,12 @@ contract LendingMarketController is
             collateralAggregator().releaseUnsettledCollateral(maker, _ccy, settledCollateralAmount);
             Storage.slot().usedCurrencies[msg.sender].add(_ccy);
             Storage.slot().usedCurrencies[maker].add(_ccy);
+
+            if (_side == ProtocolTypes.Side.LEND) {
+                emit OrderFilled(msg.sender, maker, _ccy, _maturity, matchedAmount, _rate);
+            } else {
+                emit OrderFilled(maker, msg.sender, _ccy, _maturity, matchedAmount, _rate);
+            }
         }
 
         return true;

--- a/contracts/interfaces/ILendingMarketController.sol
+++ b/contracts/interfaces/ILendingMarketController.sol
@@ -19,6 +19,14 @@ interface ILendingMarketController {
         uint256 maturity
     );
     event LendingMarketsRotated(bytes32 ccy, uint256 oldMaturity, uint256 newMaturity);
+    event OrderFilled(
+        address lender,
+        address borrower,
+        bytes32 ccy,
+        uint256 maturity,
+        uint256 amount,
+        uint256 rate
+    );
 
     function getBasisDate(bytes32 _ccy) external view returns (uint256);
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -662,7 +662,9 @@ contract('Integration test', async (accounts) => {
       );
       expect(maxWithdrawalBob.toString()).to.equal(
         independentCollateralBob
-          .add(totalPresentValueBob.mul('3').div('2'))
+          .mul('10')
+          .add(totalPresentValueBob.mul('15'))
+          .div('10')
           .toString(),
       );
 

--- a/test/lending-market-controller.js
+++ b/test/lending-market-controller.js
@@ -281,17 +281,27 @@ contract('LendingMarketController', () => {
             '800',
           ),
       ).to.equal(true);
-      await expect(
-        lendingMarketControllerProxy
-          .connect(carol)
-          .createOrder(
-            targetCurrency,
-            maturities[0],
-            Side.BORROW,
-            '100000000000000000',
-            '800',
-          ),
-      ).to.emit(lendingMarket1, 'TakeOrder');
+      const tx = lendingMarketControllerProxy
+        .connect(carol)
+        .createOrder(
+          targetCurrency,
+          maturities[0],
+          Side.BORROW,
+          '100000000000000000',
+          '800',
+        );
+
+      await expect(tx).to.emit(lendingMarket1, 'TakeOrder');
+      await expect(tx)
+        .to.emit(lendingMarketControllerProxy, 'OrderFilled')
+        .withArgs(
+          alice.address,
+          carol.address,
+          targetCurrency,
+          maturities[0],
+          '100000000000000000',
+          '800',
+        );
 
       const maturity = await lendingMarket1.getMaturity();
       expect(maturity.toString()).to.equal(


### PR DESCRIPTION
- Add an event for when the order is filled.
- Fix an existing bug in the integration test.

This new event is not the same as the `Register` event in the LoanV2 contract but I think it is enough to create a history table.