### PR TITLE
[SF-169] Add a method to get lending market by maturity

### DIFF
--- a/contracts/LendingMarketController.sol
+++ b/contracts/LendingMarketController.sol
@@ -106,6 +106,21 @@ contract LendingMarketController is
     }
 
     /**
+     * @notice Gets the lending market contract address for the selected currency and maturity.
+     * @param _ccy Currency name in bytes32
+     * @param _maturity The maturity of the market
+     * @return The lending market address
+     */
+    function getLendingMarket(bytes32 _ccy, uint256 _maturity)
+        external
+        view
+        override
+        returns (address)
+    {
+        return Storage.slot().maturityLendingMarkets[_ccy][_maturity];
+    }
+
+    /**
      * @notice Gets borrow rates for the selected currency.
      * @param _ccy Currency name in bytes32
      * @return Array with the borrowing rate of the lending market

--- a/contracts/interfaces/ILendingMarketController.sol
+++ b/contracts/interfaces/ILendingMarketController.sol
@@ -32,6 +32,8 @@ interface ILendingMarketController {
 
     function getLendingMarkets(bytes32 _ccy) external view returns (address[] memory);
 
+    function getLendingMarket(bytes32 _ccy, uint256 _maturity) external view returns (address);
+
     function getBorrowRates(bytes32 _ccy) external view returns (uint256[] memory rates);
 
     function getLendRates(bytes32 _ccy) external view returns (uint256[] memory rates);

--- a/test/lending-market-controller.test.ts
+++ b/test/lending-market-controller.test.ts
@@ -180,10 +180,22 @@ describe('LendingMarketController', () => {
       const markets = await lendingMarketControllerProxy.getLendingMarkets(
         targetCurrency,
       );
+      const maturities = await lendingMarketControllerProxy.getMaturities(
+        targetCurrency,
+      );
+      const market = await lendingMarketControllerProxy.getLendingMarket(
+        targetCurrency,
+        maturities[0],
+      );
 
       expect(markets.length).to.equal(1);
+      expect(maturities.length).to.equal(1);
       expect(markets[0]).to.exist;
       expect(markets[0]).to.not.equal(ethers.constants.AddressZero);
+      expect(markets[0]).to.equal(market);
+      expect(maturities[0].toString()).to.equal(
+        moment.unix(basisDate).add(3, 'M').unix().toString(),
+      );
     });
 
     it('Create multiple lending markets', async () => {
@@ -199,17 +211,30 @@ describe('LendingMarketController', () => {
       const markets = await lendingMarketControllerProxy.getLendingMarkets(
         targetCurrency,
       );
+      const maturities = await lendingMarketControllerProxy.getMaturities(
+        targetCurrency,
+      );
 
       expect(markets.length).to.equal(3);
+      expect(maturities.length).to.equal(3);
       markets.forEach((market) => {
         expect(market).to.not.equal(ethers.constants.AddressZero);
         expect(market).to.exist;
+      });
+      maturities.forEach((maturity, i) => {
+        expect(maturity.toString()).to.equal(
+          moment
+            .unix(basisDate)
+            .add(3 * (i + 1), 'M')
+            .unix()
+            .toString(),
+        );
       });
     });
   });
 
   describe('Order', async () => {
-    let lendingMarketProxies;
+    let lendingMarketProxies: Contract[];
 
     beforeEach(async () => {
       await lendingMarketControllerProxy.initializeLendingMarket(


### PR DESCRIPTION
- Add a method to get the Lending Market contract address using currency & maturity from the Lending Market Controller contract.