### PR TITLE
fix: fix TokenVault to transfer token correctly [SF-210]

### DIFF
--- a/contracts/LendingMarketController.sol
+++ b/contracts/LendingMarketController.sol
@@ -375,7 +375,7 @@ contract LendingMarketController is
         if (side == ProtocolTypes.Side.LEND) {
             tokenVault().removeEscrowedAmount(msg.sender, msg.sender, _ccy, amount);
         } else {
-            tokenVault().releaseUnsettledCollateral(msg.sender, _ccy, amount, true);
+            tokenVault().releaseUnsettledCollateral(msg.sender, address(0), _ccy, amount);
         }
 
         emit OrderCanceled(_orderId, msg.sender, _ccy, side, _maturity, amount, rate);
@@ -524,7 +524,7 @@ contract LendingMarketController is
             emit OrderPlaced(orderId, maker, _ccy, _side, _maturity, _amount, _rate);
         } else {
             if (_side == ProtocolTypes.Side.LEND) {
-                tokenVault().releaseUnsettledCollateral(maker, _ccy, _amount, false);
+                tokenVault().releaseUnsettledCollateral(maker, msg.sender, _ccy, _amount);
             } else {
                 tokenVault().removeEscrowedAmount(maker, msg.sender, _ccy, _amount);
             }

--- a/contracts/interfaces/ITokenVault.sol
+++ b/contracts/interfaces/ITokenVault.sol
@@ -57,9 +57,9 @@ interface ITokenVault {
 
     function releaseUnsettledCollateral(
         address user,
+        address sender,
         bytes32 ccy,
-        uint256 amount,
-        bool skipWithdrawal
+        uint256 amount
     ) external;
 
     function setCollateralParameters(

--- a/contracts/mocks/TokenVaultCallerMock.sol
+++ b/contracts/mocks/TokenVaultCallerMock.sol
@@ -23,11 +23,11 @@ contract TokenVaultCallerMock {
 
     function releaseUnsettledCollateral(
         address user,
+        address sender,
         bytes32 ccy,
-        uint256 amount,
-        bool skipWithdrawal
+        uint256 amount
     ) public {
-        tokenVault.releaseUnsettledCollateral(user, ccy, amount, skipWithdrawal);
+        tokenVault.releaseUnsettledCollateral(user, sender, ccy, amount);
     }
 
     function addEscrowedAmount(

--- a/test/token-vault.test.ts
+++ b/test/token-vault.test.ts
@@ -344,7 +344,12 @@ describe('TokenVault', () => {
       await expect(
         tokenVaultProxy
           .connect(alice)
-          .releaseUnsettledCollateral(carol.address, targetCurrency, '1', true),
+          .releaseUnsettledCollateral(
+            carol.address,
+            alice.address,
+            targetCurrency,
+            '1',
+          ),
       ).to.be.revertedWith('Only Accepted Contracts');
     });
   });


### PR DESCRIPTION
- Change method from `withdrawAssets` to `safeTransferFrom` in the `releaseUnsettledCollateral` method in TokenVault.