### PR TITLE
fix: update npm version [SF-34]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secured-finance/smart-contracts",
-  "version": "0.0.4-beta.1",
+  "version": "0.0.4",
   "description": "Secured Finance protocol smart contracts",
   "scripts": {
     "test": "hardhat test",


### PR DESCRIPTION
The publishing workflow failed because `0.0.4-beta.1` is already published somehow.
I guess it is caused by the former failed workflow.
To avoid this error I updated npm version.