### PR TITLE
fix: fix the publishing workflow bug by codegen [SF-34]

### DIFF
--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -143,8 +143,6 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - name: Update documents
-        run: npm run docgen
       - name: 'Setup npm'
         run: |
           npm set @secured-finance:registry=https://npm.pkg.github.com
@@ -164,6 +162,8 @@ jobs:
             npm version prerelease --preid beta
           fi
           npm publish
+      - name: Update documents
+        run: npm run docgen
       - name: Commit and push
         shell: bash
         run: |


### PR DESCRIPTION
- Move `docgen` step to after `npm publish` because `npm publish` command fail if there are changed files by `docgen` command.