### PR TITLE
fix: fix a bug in retister-orders task [SF-260]

### DIFF
--- a/.github/workflows/register-orders.yaml
+++ b/.github/workflows/register-orders.yaml
@@ -11,13 +11,24 @@ on:
         options:
           - development
           - staging
-      currency:
-        description: 'Currency'
+      collateralCurrency:
+        description: 'CollateralCurrency'
+        required: true
+        default: 'ETH'
+        type: choice
+        options:
+          - ETH
+          - USDC
+      marketCurrency:
+        description: 'MarketCurrency'
         required: true
         default: 'FIL'
         type: choice
         options:
           - FIL
+          - ETH
+          - USDC
+          - BTC
       maturity:
         description: 'Maturity'
         required: true
@@ -63,7 +74,8 @@ jobs:
         run: >
           npx hardhat register-orders
           --network ${{ github.event.inputs.network }}
-          --currency ${{ github.event.inputs.currency }}
+          --collateral-currency ${{ github.event.inputs.collateralCurrency }}
+          --market-currency ${{ github.event.inputs.marketCurrency }}
           --maturity ${{ github.event.inputs.maturity }}
           --mid-unit-price ${{ github.event.inputs.midUnitPrice }}
           --amount ${{ github.event.inputs.orderAmount }}


### PR DESCRIPTION
- Fix a bug in the `register-orders` task.
- Add acceptable currencies as collateral to input on the `register-orders` task