### PR TITLE
fix: fix an publishing workflow bug [SF-272]

### DIFF
--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -122,6 +122,9 @@ jobs:
     if: ${{ always() && github.actor != 'secured-finance-machine-user[bot]' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'canceled') }}
     needs: [test, deploy]
     steps:
+      - name: Check conditional job statues
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        run: exit 1
       - name: Generate token
         id: generate_token
         uses: tibdex/github-app-token@v1


### PR DESCRIPTION
Fix a bug that the workflow to publish smart contracts is executed even if a previous workflow fails.