### PR TITLE
fix: fix a bug in the deployment workflow [SF-273]

### DIFF
--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -105,6 +105,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.DEV_PRIVATE_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY }}
           UNISWAP_SWAP_ROUTER_CONTRACT: ${{ secrets.DEV_UNISWAP_SWAP_ROUTER_CONTRACT }}
+          UNISWAP_SWAP_QUOTER_CONTRACT: ${{ secrets.DEV_UNISWAP_SWAP_QUOTER_CONTRACT }}
           TOKEN_EFIL: ${{ secrets.DEV_TOKEN_EFIL }}
           TOKEN_USDC: ${{ secrets.DEV_TOKEN_USDC }}
           TOKEN_WBTC: ${{ secrets.DEV_TOKEN_WBTC }}
@@ -116,6 +117,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.STG_PRIVATE_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.STG_ALCHEMY_API_KEY }}
           UNISWAP_SWAP_ROUTER_CONTRACT: ${{ secrets.STG_UNISWAP_SWAP_ROUTER_CONTRACT }}
+          UNISWAP_SWAP_QUOTER_CONTRACT: ${{ secrets.STG_UNISWAP_SWAP_QUOTER_CONTRACT }}
           TOKEN_EFIL: ${{ secrets.STG_TOKEN_EFIL }}
           TOKEN_USDC: ${{ secrets.STG_TOKEN_USDC }}
           TOKEN_WBTC: ${{ secrets.STG_TOKEN_WBTC }}

--- a/.github/workflows/reset-smart-contracts.yml
+++ b/.github/workflows/reset-smart-contracts.yml
@@ -45,6 +45,7 @@ jobs:
           ALCHEMY_API_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY }}
           INITIAL_COMPOUND_FACTOR: ${{ github.event.inputs.compoundFactor }}
           UNISWAP_SWAP_ROUTER_CONTRACT: ${{ secrets.DEV_UNISWAP_SWAP_ROUTER_CONTRACT }}
+          UNISWAP_SWAP_QUOTER_CONTRACT: ${{ secrets.DEV_UNISWAP_SWAP_QUOTER_CONTRACT }}
           TOKEN_EFIL: ${{ secrets.DEV_TOKEN_EFIL }}
           TOKEN_USDC: ${{ secrets.DEV_TOKEN_USDC }}
           TOKEN_WBTC: ${{ secrets.DEV_TOKEN_WBTC }}
@@ -57,6 +58,7 @@ jobs:
           ALCHEMY_API_KEY: ${{ secrets.STG_ALCHEMY_API_KEY }}
           INITIAL_COMPOUND_FACTOR: ${{ github.event.inputs.compoundFactor }}
           UNISWAP_SWAP_ROUTER_CONTRACT: ${{ secrets.STG_UNISWAP_SWAP_ROUTER_CONTRACT }}
+          UNISWAP_SWAP_QUOTER_CONTRACT: ${{ secrets.STG_UNISWAP_SWAP_QUOTER_CONTRACT }}
           TOKEN_EFIL: ${{ secrets.STG_TOKEN_EFIL }}
           TOKEN_USDC: ${{ secrets.STG_TOKEN_USDC }}
           TOKEN_WBTC: ${{ secrets.STG_TOKEN_WBTC }}


### PR DESCRIPTION
I just noticed we could use Environment secrets instead of Repository secrets on GitHub.
But it will be big changes so I will add only missed value as Environment secrets for now.

- Add environment settings in the deployment workflow to fix a bug.