### PR TITLE
fix a publishing workflow bug

### DIFF
--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -83,6 +83,7 @@ jobs:
   publish:
     name: Deploy Smart Contracts
     runs-on: ubuntu-latest
+    if: ${{ always() && github.actor != 'secured-finance-machine-user[bot]' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'canceled') }}
     needs: [test]
     steps:
       - name: Generate token


### PR DESCRIPTION
Fix a bug that the publishing workflow does not work when after the smart contract reset workflow is executed.