### PR TITLE
refactor code to reduce contract size

### DIFF
--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -404,10 +404,10 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
     }
 
     /**
-     * @notice Cleans own orders to remove order ids that are already filled on the order book.
+     * @notice Cleans up own orders to remove order ids that are already filled on the order book.
      * @dev The order list per user is not updated in real-time when an order is filled.
      * This function removes the filled order from that order list per user to reduce gas costs
-     * for calculating if the collateral is enough or not.
+     * for lazy evaluation if the collateral is enough or not.
      *
      * @param _user User address
      * @return activeLendOrderCount The total amount of active lend order on the order book
@@ -418,7 +418,7 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
      * @return removedBorrowOrderAmount The total PV amount of the removed borrow order amount from the order book
      * @return maturity The maturity of the removed orders
      */
-    function cleanOrders(address _user)
+    function cleanUpOrders(address _user)
         external
         override
         returns (

--- a/contracts/TokenVault.sol
+++ b/contracts/TokenVault.sol
@@ -525,7 +525,7 @@ contract TokenVault is ITokenVault, MixinAddressResolver, Ownable, Proxyable {
     ) internal {
         require(_amount > 0, "Invalid amount");
 
-        lendingMarketController().cleanOrders(_ccy, _user);
+        lendingMarketController().cleanUpFunds(_ccy, _user);
         uint256 withdrawableAmount = DepositManagementLogic.withdraw(_user, _ccy, _amount);
         ERC20Handler.withdrawAssets(Storage.slot().tokenAddresses[_ccy], _user, withdrawableAmount);
 

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -175,7 +175,7 @@ interface ILendingMarket {
 
     function executeItayoseCall() external returns (uint256 openingUnitPrice, uint256 openingDate);
 
-    function cleanOrders(address _user)
+    function cleanUpOrders(address _user)
         external
         returns (
             uint256 activeLendOrderCount,

--- a/contracts/interfaces/ILendingMarketController.sol
+++ b/contracts/interfaces/ILendingMarketController.sol
@@ -13,31 +13,6 @@ interface ILendingMarketController {
         uint256 maturity
     );
     event LendingMarketsRotated(bytes32 ccy, uint256 oldMaturity, uint256 newMaturity);
-    event OrderFilled(
-        address indexed taker,
-        bytes32 indexed ccy,
-        ProtocolTypes.Side side,
-        uint256 indexed maturity,
-        uint256 amount,
-        uint256 unitPrice,
-        uint256 filledFutureValue
-    );
-    event OrdersFilledInAsync(
-        address indexed taker,
-        bytes32 indexed ccy,
-        ProtocolTypes.Side side,
-        uint256 indexed maturity,
-        uint256 filledFutureValue
-    );
-    event OrderCanceled(
-        uint48 orderId,
-        address indexed maker,
-        bytes32 indexed ccy,
-        ProtocolTypes.Side side,
-        uint256 maturity,
-        uint256 amount,
-        uint256 unitPrice
-    );
     event LiquidationExecuted(
         address indexed user,
         bytes32 collateralCcy,
@@ -216,7 +191,7 @@ interface ILendingMarketController {
 
     function unpauseLendingMarkets(bytes32 ccy) external returns (bool);
 
-    function cleanAllOrders(address user) external;
+    function cleanUpAllFunds(address user) external;
 
-    function cleanOrders(bytes32 ccy, address user) external returns (uint256 activeOrderCount);
+    function cleanUpFunds(bytes32 ccy, address user) external returns (uint256 activeOrderCount);
 }

--- a/contracts/mocks/TokenVaultCallerMock.sol
+++ b/contracts/mocks/TokenVaultCallerMock.sol
@@ -99,7 +99,7 @@ contract TokenVaultCallerMock {
         return lendingMarketController.calculateFunds(_ccy, _user);
     }
 
-    function cleanOrders(bytes32 _ccy, address _user) public returns (uint256 activeOrderCount) {
-        return lendingMarketController.cleanOrders(_ccy, _user);
+    function cleanUpFunds(bytes32 _ccy, address _user) public returns (uint256 activeOrderCount) {
+        return lendingMarketController.cleanUpFunds(_ccy, _user);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18351,7 +18351,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -18664,7 +18663,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/scripts/zc-e2e.ts
+++ b/scripts/zc-e2e.ts
@@ -218,11 +218,11 @@ describe('ZC e2e test', async () => {
       )
       .then((tx) => tx.wait());
 
-    await lendingMarketController.cleanOrders(
+    await lendingMarketController.cleanUpFunds(
       targetCurrency,
       aliceSigner.address,
     );
-    await lendingMarketController.cleanOrders(
+    await lendingMarketController.cleanUpFunds(
       targetCurrency,
       bobSigner.address,
     );

--- a/test/common/deployment.ts
+++ b/test/common/deployment.ts
@@ -288,6 +288,7 @@ const deployContracts = async () => {
 
   return {
     genesisDate,
+    fundManagementLogic,
     // contracts
     addressResolver: addressResolverProxy,
     beaconProxyController: beaconProxyControllerProxy,

--- a/test/integration/auto-rolls.test.ts
+++ b/test/integration/auto-rolls.test.ts
@@ -240,7 +240,7 @@ describe('Integration Test: Auto-rolls', async () => {
       expect(aliceFVBefore).to.equal('0');
       expect(bobFV).not.to.equal('0');
 
-      await lendingMarketController.cleanOrders(hexWETH, alice.address);
+      await lendingMarketController.cleanUpFunds(hexWETH, alice.address);
       const { futureValue: aliceFVAfter } =
         await futureValueVaults[0].getFutureValue(alice.address);
 
@@ -636,7 +636,7 @@ describe('Integration Test: Auto-rolls', async () => {
         alice.address,
       );
 
-      await lendingMarketController.cleanOrders(hexWETH, alice.address);
+      await lendingMarketController.cleanUpFunds(hexWETH, alice.address);
 
       const alicePV0After = await lendingMarketController.getPresentValue(
         hexWETH,
@@ -830,7 +830,7 @@ describe('Integration Test: Auto-rolls', async () => {
     it('Check future values', async () => {
       const checkFutureValue = async () => {
         for (const { address } of [owner, alice, bob, carol]) {
-          await lendingMarketController.cleanOrders(hexWETH, address);
+          await lendingMarketController.cleanUpFunds(hexWETH, address);
         }
 
         const gvAmounts = await Promise.all(
@@ -870,7 +870,7 @@ describe('Integration Test: Auto-rolls', async () => {
       );
 
       for (const { address } of users) {
-        await lendingMarketController.cleanOrders(hexWETH, address);
+        await lendingMarketController.cleanUpFunds(hexWETH, address);
       }
 
       const [

--- a/test/integration/liquidations.test.ts
+++ b/test/integration/liquidations.test.ts
@@ -35,6 +35,8 @@ describe('Integration Test: Liquidations', async () => {
   let eFilToETHPriceFeed: Contract;
   let usdcToUSDPriceFeed: Contract;
 
+  let fundManagementLogic: Contract;
+
   let mockUniswapRouter: Contract;
   let mockUniswapQuoter: Contract;
 
@@ -185,6 +187,7 @@ describe('Integration Test: Liquidations', async () => {
 
     ({
       genesisDate,
+      fundManagementLogic,
       addressResolver,
       tokenVault,
       lendingMarketController,
@@ -302,7 +305,10 @@ describe('Integration Test: Liquidations', async () => {
               filledOrderAmount,
               '0',
             ),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         await lendingMarketController
           .connect(owner)
@@ -500,7 +506,10 @@ describe('Integration Test: Liquidations', async () => {
               filledOrderAmount,
               '0',
             ),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         await lendingMarketController
           .connect(owner)
@@ -632,7 +641,10 @@ describe('Integration Test: Liquidations', async () => {
               filledOrderAmount,
               '0',
             ),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         await lendingMarketController
           .connect(owner)
@@ -798,7 +810,10 @@ describe('Integration Test: Liquidations', async () => {
               filledOrderAmount,
               '0',
             ),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         await lendingMarketController
           .connect(owner)
@@ -930,7 +945,10 @@ describe('Integration Test: Liquidations', async () => {
               filledOrderAmount,
               '0',
             ),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         await lendingMarketController
           .connect(owner)
@@ -1102,7 +1120,10 @@ describe('Integration Test: Liquidations', async () => {
             filledOrderAmountInFIL,
             '0',
           ),
-      ).to.emit(lendingMarketController, 'OrderFilled');
+      ).to.emit(
+        fundManagementLogic.attach(lendingMarketController.address),
+        'OrderFilled',
+      );
 
       await lendingMarketController
         .connect(owner)
@@ -1155,7 +1176,10 @@ describe('Integration Test: Liquidations', async () => {
             filledOrderAmountInUSDC,
             '0',
           ),
-      ).to.emit(lendingMarketController, 'OrderFilled');
+      ).to.emit(
+        fundManagementLogic.attach(lendingMarketController.address),
+        'OrderFilled',
+      );
 
       await lendingMarketController
         .connect(owner)

--- a/test/integration/order-book.test.ts
+++ b/test/integration/order-book.test.ts
@@ -30,6 +30,8 @@ describe('Integration Test: Order Book', async () => {
   let mockUniswapRouter: Contract;
   let mockUniswapQuoter: Contract;
 
+  let fundManagementLogic: Contract;
+
   let genesisDate: number;
   let filLendingMarkets: Contract[] = [];
   let filMaturities: BigNumber[];
@@ -85,6 +87,7 @@ describe('Integration Test: Order Book', async () => {
 
     ({
       genesisDate,
+      fundManagementLogic,
       addressResolver,
       currencyController,
       tokenVault,
@@ -231,7 +234,10 @@ describe('Integration Test: Order Book', async () => {
           lendingMarketController
             .connect(alice)
             .unwindOrder(hexWETH, ethMaturities[0]),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         const aliceFV = await lendingMarketController.getFutureValue(
           hexWETH,
@@ -360,7 +366,10 @@ describe('Integration Test: Order Book', async () => {
           lendingMarketController
             .connect(alice)
             .unwindOrder(hexEFIL, filMaturities[0]),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         const aliceFV = await lendingMarketController.getFutureValue(
           hexEFIL,
@@ -556,7 +565,10 @@ describe('Integration Test: Order Book', async () => {
           lendingMarketController
             .connect(alice)
             .unwindOrder(hexEFIL, filMaturities[0]),
-        ).to.emit(lendingMarketController, 'OrderFilled');
+        ).to.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         const aliceFVAfter = await lendingMarketController.getFutureValue(
           hexEFIL,
@@ -958,7 +970,10 @@ describe('Integration Test: Order Book', async () => {
               orderAmountInFIL,
               '8000',
             ),
-        ).to.not.emit(lendingMarketController, 'OrderFilled');
+        ).to.not.emit(
+          fundManagementLogic.attach(lendingMarketController.address),
+          'OrderFilled',
+        );
 
         const totalCollateralAmountAfter =
           await tokenVault.getTotalCollateralAmount(alice.address);

--- a/test/unit/token-vault.test.ts
+++ b/test/unit/token-vault.test.ts
@@ -79,7 +79,7 @@ describe('TokenVault', () => {
     await mockERC20.mock.transferFrom.returns(true);
     await mockERC20.mock.transfer.returns(true);
     await mockERC20.mock.approve.returns(true);
-    await mockLendingMarketController.mock.cleanOrders.returns(0);
+    await mockLendingMarketController.mock.cleanUpFunds.returns(0);
     await mockLendingMarketController.mock.getTotalPresentValueInETH.returns(0);
     await mockLendingMarketController.mock.calculateTotalFundsInETH.returns(
       0,


### PR DESCRIPTION
- Refactor code to reduce contract size because `LendingMarketController.sol` is going to reach to contract maximum size.
- Rename each `cleanOrders` function to `cleanUpOrders` and `cleanUpFunds`.