### PR TITLE
update logic for partially filling orders to reduce gas costs

### DIFF
--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -5,6 +5,12 @@ import "../types/ProtocolTypes.sol";
 import {MarketOrder} from "../storages/LendingMarketStorage.sol";
 
 interface ILendingMarket {
+    struct PartiallyFilledOrder {
+        address maker;
+        uint256 amount;
+        uint256 futureValue;
+    }
+
     event OrderCanceled(
         uint48 orderId,
         address indexed maker,
@@ -14,6 +20,7 @@ interface ILendingMarket {
         uint256 amount,
         uint256 unitPrice
     );
+
     event OrderMade(
         uint48 orderId,
         uint48 originalOrderId,
@@ -24,6 +31,7 @@ interface ILendingMarket {
         uint256 amount,
         uint256 unitPrice
     );
+
     event OrdersTaken(
         address indexed taker,
         ProtocolTypes.Side side,
@@ -31,6 +39,16 @@ interface ILendingMarket {
         uint256 maturity,
         uint256 filledAmount,
         uint256 unitPrice,
+        uint256 filledFutureValue
+    );
+
+    event OrderPartiallyTaken(
+        uint48 orderId,
+        address indexed maker,
+        ProtocolTypes.Side side,
+        bytes32 indexed ccy,
+        uint256 maturity,
+        uint256 filledAmount,
         uint256 filledFutureValue
     );
 
@@ -170,10 +188,18 @@ interface ILendingMarket {
         returns (
             uint256 filledUnitPrice,
             uint256 filledAmount,
-            uint256 filledFutureValue
+            uint256 filledFutureValue,
+            PartiallyFilledOrder memory partiallyFilledOrder
         );
 
-    function executeItayoseCall() external returns (uint256 openingUnitPrice, uint256 openingDate);
+    function executeItayoseCall()
+        external
+        returns (
+            uint256 openingUnitPrice,
+            uint256 openingDate,
+            PartiallyFilledOrder memory partiallyFilledLendingOrder,
+            PartiallyFilledOrder memory partiallyFilledBorrowingOrder
+        );
 
     function cleanUpOrders(address _user)
         external
@@ -198,6 +224,7 @@ interface ILendingMarket {
         returns (
             uint256 filledUnitPrice,
             uint256 filledFutureValue,
+            PartiallyFilledOrder memory partiallyFilledOrder,
             uint256 remainingAmount
         );
 

--- a/contracts/mocks/LendingMarketCaller.sol
+++ b/contracts/mocks/LendingMarketCaller.sol
@@ -46,7 +46,12 @@ contract LendingMarketCaller {
 
     function executeItayoseCall(uint256 _index)
         external
-        returns (uint256 openingUnitPrice, uint256 openingDate)
+        returns (
+            uint256 openingUnitPrice,
+            uint256 openingDate,
+            ILendingMarket.PartiallyFilledOrder memory lendingOrder,
+            ILendingMarket.PartiallyFilledOrder memory borrowingOrder
+        )
     {
         return ILendingMarket(lendingMarkets[_index]).executeItayoseCall();
     }

--- a/contracts/mocks/OrderStatisticsTreeContract.sol
+++ b/contracts/mocks/OrderStatisticsTreeContract.sol
@@ -12,10 +12,10 @@ contract OrderStatisticsTreeContract {
     event OrderRemoved(string action, uint256 value, uint256 _id);
 
     event Drop(
-        uint256 droppedAmountInPV,
-        uint256 droppedAmountInFV,
-        uint256 remainingOrderAmountInPV,
-        uint256 remainingOrderUnitPrice
+        uint256 droppedAmount,
+        uint256 droppedFutureValue,
+        uint256 filledOrderAmount,
+        uint256 filledOrderFutureValue
     );
 
     constructor() {}
@@ -112,16 +112,16 @@ contract OrderStatisticsTreeContract {
     ) public {
         (
             ,
-            uint256 droppedAmountInPV,
-            uint256 droppedAmountInFV,
+            uint256 droppedAmount,
+            uint256 droppedFutureValue,
             ,
-            RemainingOrder memory remainingOrder
+            PartiallyFilledOrder memory partiallyFilledOrder
         ) = tree.dropLeft(value, limitValue, limitFutureValue);
         emit Drop(
-            droppedAmountInPV,
-            droppedAmountInFV,
-            remainingOrder.amount,
-            remainingOrder.unitPrice
+            droppedAmount,
+            droppedFutureValue,
+            partiallyFilledOrder.amount,
+            partiallyFilledOrder.futureValue
         );
     }
 
@@ -132,16 +132,16 @@ contract OrderStatisticsTreeContract {
     ) public {
         (
             ,
-            uint256 droppedAmountInPV,
-            uint256 droppedAmountInFV,
+            uint256 droppedAmount,
+            uint256 droppedFutureValue,
             ,
-            RemainingOrder memory remainingOrder
+            PartiallyFilledOrder memory partiallyFilledOrder
         ) = tree.dropRight(value, limitValue, limitFutureValue);
         emit Drop(
-            droppedAmountInPV,
-            droppedAmountInFV,
-            remainingOrder.amount,
-            remainingOrder.unitPrice
+            droppedAmount,
+            droppedFutureValue,
+            partiallyFilledOrder.amount,
+            partiallyFilledOrder.futureValue
         );
     }
 }

--- a/contracts/storages/LendingMarketStorage.sol
+++ b/contracts/storages/LendingMarketStorage.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../types/ProtocolTypes.sol";
-import "../libraries/OrderStatisticsTreeLib.sol";
+import {ProtocolTypes} from "../types/ProtocolTypes.sol";
+import {OrderStatisticsTreeLib} from "../libraries/OrderStatisticsTreeLib.sol";
 
 struct MarketOrder {
     ProtocolTypes.Side side;

--- a/test/integration/order-book.test.ts
+++ b/test/integration/order-book.test.ts
@@ -211,7 +211,6 @@ describe('Integration Test: Order Book', async () => {
       });
 
       it('Check collateral', async () => {
-        const coverage = await tokenVault.getCoverage(alice.address);
         const aliceDepositAmount = await tokenVault.getDepositAmount(
           alice.address,
           hexETH,
@@ -253,10 +252,12 @@ describe('Integration Test: Order Book', async () => {
         );
 
         expect(aliceFV).to.equal(0);
+      });
 
+      after(async () => {
         await lendingMarketController
           .connect(carol)
-          .cancelOrder(hexETH, ethMaturities[0], '5');
+          .cancelOrder(hexETH, ethMaturities[0], '4');
       });
     });
 
@@ -316,7 +317,7 @@ describe('Integration Test: Order Book', async () => {
         const fee = calculateOrderFee(
           orderAmount,
           '8000',
-          ethMaturities[0].sub(timestamp),
+          filMaturities[0].sub(timestamp),
         );
 
         const [aliceFV, bobFV] = await Promise.all(
@@ -334,7 +335,6 @@ describe('Integration Test: Order Book', async () => {
       });
 
       it('Check collateral', async () => {
-        const coverage = await tokenVault.getCoverage(alice.address);
         const aliceFILDepositAmount = await tokenVault.getDepositAmount(
           alice.address,
           hexEFIL,
@@ -391,10 +391,12 @@ describe('Integration Test: Order Book', async () => {
         );
 
         expect(aliceFV).to.equal(0);
+      });
 
+      after(async () => {
         await lendingMarketController
           .connect(dave)
-          .cancelOrder(hexEFIL, filMaturities[0], '5');
+          .cancelOrder(hexEFIL, filMaturities[0], '4');
       });
     });
 

--- a/test/unit/lending-market-controller-itayose.test.ts
+++ b/test/unit/lending-market-controller-itayose.test.ts
@@ -77,6 +77,8 @@ describe('LendingMarketController - Itayose', () => {
     mockTokenVault = await deployMockContract(owner, TokenVault.abi);
     await mockCurrencyController.mock.currencyExists.returns(true);
     await mockTokenVault.mock.isCovered.returns(true);
+    await mockTokenVault.mock.addDepositAmount.returns();
+    await mockTokenVault.mock.removeDepositAmount.returns();
 
     // Deploy libraries
     const quickSort = await deployContract(owner, QuickSort);

--- a/test/unit/lending-market-controller.test.ts
+++ b/test/unit/lending-market-controller.test.ts
@@ -1231,7 +1231,7 @@ describe('LendingMarketController', () => {
             maturities[0],
             Side.LEND,
             '50000000000000000',
-            '8800',
+            '8000',
           );
 
         await lendingMarketControllerProxy
@@ -1241,7 +1241,7 @@ describe('LendingMarketController', () => {
             maturities[0],
             Side.LEND,
             '50000000000000000',
-            '8800',
+            '8000',
           );
 
         const tx = await lendingMarketControllerProxy
@@ -1251,7 +1251,7 @@ describe('LendingMarketController', () => {
             maturities[0],
             Side.BORROW,
             '80000000000000000',
-            '8800',
+            '8000',
           );
         await expect(tx).to.emit(
           fundManagementLogic.attach(lendingMarketControllerProxy.address),
@@ -1259,16 +1259,15 @@ describe('LendingMarketController', () => {
         );
         await expect(tx).to.emit(lendingMarket1, 'OrdersTaken');
         await expect(tx)
-          .to.emit(lendingMarket1, 'OrderMade')
+          .to.emit(lendingMarket1, 'OrderPartiallyTaken')
           .withArgs(
-            3,
-            2,
+            () => true,
             bob.address,
             Side.LEND,
             targetCurrency,
             maturities[0],
-            '20000000000000000',
-            '8800',
+            '30000000000000000',
+            '37500000000000000',
           );
       });
 

--- a/test/unit/order-statistics-tree/data/borrowing-orders.ts
+++ b/test/unit/order-statistics-tree/data/borrowing-orders.ts
@@ -8,7 +8,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop all nodes',
@@ -32,7 +32,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop 1 node',
@@ -42,7 +42,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 200000000,
-        droppedAmount: 400000000,
+        droppedAmount: 200000000,
       },
       {
         title: 'Drop all nodes',
@@ -67,7 +67,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop 1 node',
@@ -77,7 +77,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 200000000,
-        droppedAmount: 400000000,
+        droppedAmount: 200000000,
       },
       {
         title: 'Drop 2 nodes',
@@ -114,7 +114,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially, Remove 1 order with a unfilled amount',
         targetAmount: 25000000,
-        droppedAmount: 50000000,
+        droppedAmount: 25000000,
       },
       {
         title:
@@ -130,13 +130,13 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 150000000,
-        droppedAmount: 200000000,
+        droppedAmount: 150000000,
       },
       {
         title:
           'Drop 1 node, Fill 1 node partially, Remove 2 order with a unfilled amount',
         targetAmount: 280000000,
-        droppedAmount: 300000000,
+        droppedAmount: 280000000,
       },
       {
         title:
@@ -152,13 +152,13 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Drop 2 nodes, Fill 1 node partially',
         targetAmount: 450000000,
-        droppedAmount: 500000000,
+        droppedAmount: 450000000,
       },
       {
         title:
           'Drop 2 nodes, Fill 1 node partially, Remove 3 order with a unfilled amount',
         targetAmount: 650000000,
-        droppedAmount: 700000000,
+        droppedAmount: 650000000,
       },
       {
         title:
@@ -202,7 +202,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop 1 node',
@@ -218,7 +218,7 @@ const borrowingMarketOrders: Condition[] = [
         title:
           'Drop multiple nodes less than the root, Fill root node partially',
         targetAmount: 1300000000,
-        droppedAmount: 1600000000,
+        droppedAmount: 1300000000,
       },
       {
         title: 'Drop multiple nodes less than or equal to the root',
@@ -228,7 +228,7 @@ const borrowingMarketOrders: Condition[] = [
       {
         title: 'Drop multiple nodes across the root',
         targetAmount: 3000000000,
-        droppedAmount: 4600000000,
+        droppedAmount: 3000000000,
       },
       {
         title: 'Drop all nodes',
@@ -290,7 +290,7 @@ const borrowingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 200000000,
         limitValue: 9801,
-        droppedAmount: 400000000,
+        droppedAmount: 200000000,
         droppedValue: 9800,
       },
       {
@@ -335,7 +335,7 @@ const borrowingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 200000000,
         limitValue: 9801,
-        droppedAmount: 400000000,
+        droppedAmount: 200000000,
         droppedValue: 9800,
       },
       {
@@ -387,7 +387,7 @@ const borrowingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 200000000,
         limitValue: 9803,
-        droppedAmount: 400000000,
+        droppedAmount: 200000000,
         droppedValue: 9800,
       },
       {
@@ -416,7 +416,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -453,7 +453,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -467,7 +467,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         limitFutureValue: 375000000,
-        droppedAmount: 645500000,
+        droppedAmount: 301250000,
         filledAmount: 301250000,
         filledFutureValue: 375000000,
       },
@@ -505,7 +505,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -519,7 +519,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         limitFutureValue: 375000000,
-        droppedAmount: 645500000,
+        droppedAmount: 301250000,
         filledAmount: 301250000,
         filledFutureValue: 375000000,
       },
@@ -533,7 +533,7 @@ const borrowingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 2 nodes, Fill 1 node partially',
         limitFutureValue: 1000000000,
-        droppedAmount: 973500000,
+        droppedAmount: 809500000,
         filledAmount: 809500000,
         filledFutureValue: 1000000000,
       },

--- a/test/unit/order-statistics-tree/data/lending-orders.ts
+++ b/test/unit/order-statistics-tree/data/lending-orders.ts
@@ -8,7 +8,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop all nodes',
@@ -32,7 +32,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 100000000,
-        droppedAmount: 300000000,
+        droppedAmount: 100000000,
       },
       {
         title: 'Drop 1 node',
@@ -42,7 +42,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 350000000,
-        droppedAmount: 400000000,
+        droppedAmount: 350000000,
       },
       {
         title: 'Drop all nodes',
@@ -67,7 +67,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 300000000,
-        droppedAmount: 500000000,
+        droppedAmount: 300000000,
       },
       {
         title: 'Drop 1 node',
@@ -77,7 +77,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 600000000,
-        droppedAmount: 800000000,
+        droppedAmount: 600000000,
       },
       {
         title: 'Drop 2 nodes',
@@ -114,7 +114,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially, Remove 4 order with a unfilled amount',
         targetAmount: 350000000,
-        droppedAmount: 400000000,
+        droppedAmount: 350000000,
       },
       {
         title:
@@ -129,14 +129,14 @@ const lendingMarketOrders: Condition[] = [
       },
       {
         title: 'Drop 1 node, Fill 1 node partially',
-        targetAmount: 600000000,
-        droppedAmount: 600000000,
+        targetAmount: 580000000,
+        droppedAmount: 580000000,
       },
       {
         title:
           'Drop 1 node, Fill 1 node partially, Remove 2 order with a unfilled amount',
         targetAmount: 620000000,
-        droppedAmount: 700000000,
+        droppedAmount: 620000000,
       },
       {
         title:
@@ -152,13 +152,13 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Drop 2 nodes, Fill 1 node partially',
         targetAmount: 820000000,
-        droppedAmount: 850000000,
+        droppedAmount: 820000000,
       },
       {
         title:
           'Drop 2 nodes, Fill 1 node partially, Remove 1 order with a unfilled amount',
         targetAmount: 830000000,
-        droppedAmount: 850000000,
+        droppedAmount: 830000000,
       },
       {
         title:
@@ -202,7 +202,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Fill 1 node partially',
         targetAmount: 50000000,
-        droppedAmount: 100000000,
+        droppedAmount: 50000000,
       },
       {
         title: 'Drop 1 node',
@@ -218,7 +218,7 @@ const lendingMarketOrders: Condition[] = [
         title:
           'Drop multiple nodes less than the root, Fill root node partially',
         targetAmount: 6000000000,
-        droppedAmount: 6600000000,
+        droppedAmount: 6000000000,
       },
       {
         title: 'Drop multiple nodes less than or equal to the root',
@@ -228,7 +228,7 @@ const lendingMarketOrders: Condition[] = [
       {
         title: 'Drop multiple nodes across the root',
         targetAmount: 7000000000,
-        droppedAmount: 7100000000,
+        droppedAmount: 7000000000,
       },
       {
         title: 'Drop all nodes',
@@ -290,7 +290,7 @@ const lendingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 350000000,
         limitValue: 9800,
-        droppedAmount: 400000000,
+        droppedAmount: 350000000,
         droppedValue: 9801,
       },
       {
@@ -335,7 +335,7 @@ const lendingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 600000000,
         limitValue: 9801,
-        droppedAmount: 800000000,
+        droppedAmount: 600000000,
         droppedValue: 9802,
       },
       {
@@ -387,7 +387,7 @@ const lendingLimitOrders: Condition[] = [
         title: 'Drop 1 node, Fill 1 node partially',
         targetAmount: 700000000,
         limitValue: 9801,
-        droppedAmount: 800000000,
+        droppedAmount: 700000000,
         droppedValue: 9804,
       },
       {
@@ -416,7 +416,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -453,7 +453,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -467,7 +467,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         limitFutureValue: 350000000,
-        droppedAmount: 990000000,
+        droppedAmount: 279000000,
         filledAmount: 279000000,
         filledFutureValue: 350000000,
       },
@@ -505,7 +505,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Fill 1 node partially',
         limitFutureValue: 125000000,
-        droppedAmount: 200000000,
+        droppedAmount: 100000000,
         filledAmount: 100000000,
         filledFutureValue: 125000000,
       },
@@ -519,7 +519,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 1 node, Fill 1 node partially',
         limitFutureValue: 350000000,
-        droppedAmount: 990000000,
+        droppedAmount: 279000000,
         filledAmount: 279000000,
         filledFutureValue: 350000000,
       },
@@ -533,7 +533,7 @@ const lendingUnwindOrders: UnwindCondition[] = [
       {
         title: 'Drop 2 nodes, Fill 1 node partially',
         limitFutureValue: 1350000000,
-        droppedAmount: 1770000000,
+        droppedAmount: 1068000000,
         filledAmount: 1068000000,
         filledFutureValue: 1350000000,
       },

--- a/test/unit/order-statistics-tree/drop.test.ts
+++ b/test/unit/order-statistics-tree/drop.test.ts
@@ -238,7 +238,7 @@ describe('OrderStatisticsTree - drop values', () => {
                 }
                 const totalAmountBefore = await getTotalAmount('<Before>');
 
-                const { droppedAmountInPV, droppedAmountInFV } = await ost[
+                const { droppedAmount, droppedFutureValue } = await ost[
                   test.method
                 ](0, 0, input.limitFutureValue).then(
                   ({ logs }) => logs.find(({ event }) => event === 'Drop').args,
@@ -246,8 +246,8 @@ describe('OrderStatisticsTree - drop values', () => {
 
                 const totalAmountAfter = await getTotalAmount('<After>');
 
-                expect(droppedAmountInPV.toNumber()).equal(input.filledAmount);
-                expect(droppedAmountInFV.toNumber()).equal(
+                expect(droppedAmount.toNumber()).equal(input.filledAmount);
+                expect(droppedFutureValue.toNumber()).equal(
                   input.filledFutureValue,
                 );
                 expect(
@@ -310,7 +310,7 @@ describe('OrderStatisticsTree - drop values', () => {
 
           const totalAmountBefore = await getTotalAmount('<Before>');
 
-          const { remainingOrderAmountInPV } = await ost
+          const { droppedAmount } = await ost
             .dropValuesFromFirst(test.estimatedPVAmount, 0, 0)
             .then(
               ({ logs }) => logs.find(({ event }) => event === 'Drop').args,
@@ -318,11 +318,12 @@ describe('OrderStatisticsTree - drop values', () => {
 
           const totalAmountAfter = await getTotalAmount('<After>');
 
-          expect(
-            totalAmountAfter
-              .add(remainingOrderAmountInPV.toString())
-              .add(test.estimatedPVAmount.toString()),
-          ).to.equal(totalAmountBefore);
+          expect(droppedAmount.toString()).to.equal(
+            test.estimatedPVAmount.toString(),
+          );
+          expect(totalAmountAfter.add(droppedAmount.toString())).to.equal(
+            totalAmountBefore,
+          );
         });
       }
     });
@@ -375,7 +376,7 @@ describe('OrderStatisticsTree - drop values', () => {
 
           const totalAmountBefore = await getTotalAmount('<Before>');
 
-          const { remainingOrderAmountInPV } = await ost
+          const { droppedAmount } = await ost
             .dropValuesFromLast(test.estimatedPVAmount, 0, 0)
             .then(
               ({ logs }) => logs.find(({ event }) => event === 'Drop').args,
@@ -383,11 +384,12 @@ describe('OrderStatisticsTree - drop values', () => {
 
           const totalAmountAfter = await getTotalAmount('<After>');
 
-          expect(
-            totalAmountAfter
-              .add(remainingOrderAmountInPV.toString())
-              .add(test.estimatedPVAmount.toString()),
-          ).to.equal(totalAmountBefore);
+          expect(droppedAmount.toString()).to.equal(
+            test.estimatedPVAmount.toString(),
+          );
+          expect(totalAmountAfter.add(droppedAmount.toString())).to.equal(
+            totalAmountBefore,
+          );
         });
       }
     });


### PR DESCRIPTION
- Update logic for partially filling orders to reduce gas costs
- Add new event `OrderPartiallyTaken`.

When orders are partially filled, the filled order amount will be updated. No more new orders that have the unfilled amount are created such as previous logic.
After this PR is merged, we also need to update the `secured-finance-subgraph` repo to address the `OrderPartiallyTaken` event.