### PR TITLE
Sf 538 Add the getPositions function

### DIFF
--- a/contracts/liquidators/Liquidator.sol
+++ b/contracts/liquidators/Liquidator.sol
@@ -62,7 +62,7 @@ contract Liquidator is ILiquidationReceiver {
         uint256 _receivedCollateralAmount
     ) external override returns (bool) {
         for (uint256 i = 0; i < collateralMaturities.length; i++) {
-            int256 fvAmount = lendingMarketController.getFutureValue(
+            (, int256 fvAmount) = lendingMarketController.getPosition(
                 _collateralCcy,
                 collateralMaturities[i],
                 address(this)
@@ -102,7 +102,7 @@ contract Liquidator is ILiquidationReceiver {
             ? address(this).balance
             : IERC20(collateralCcyAddr).balanceOf(address(this));
 
-        int256 debtFVAmount = lendingMarketController.getFutureValue(
+        (, int256 debtFVAmount) = lendingMarketController.getPosition(
             _debtCcy,
             _debtMaturity,
             address(this)

--- a/contracts/protocol/LendingMarketController.sol
+++ b/contracts/protocol/LendingMarketController.sol
@@ -311,38 +311,6 @@ contract LendingMarketController is
     }
 
     /**
-     * @notice Gets the future value of the account for selected currency and maturity.
-     * @param _ccy Currency name in bytes32 for Lending Market
-     * @param _maturity The maturity of the market
-     * @param _user User's address
-     * @return futureValue The future value
-     */
-    function getFutureValue(
-        bytes32 _ccy,
-        uint256 _maturity,
-        address _user
-    ) external view override returns (int256 futureValue) {
-        futureValue = FundManagementLogic.calculateActualFunds(_ccy, _maturity, _user).futureValue;
-    }
-
-    /**
-     * @notice Gets the present value of the account for selected currency and maturity.
-     * @param _ccy Currency name in bytes32 for Lending Market
-     * @param _maturity The maturity of the market
-     * @param _user User's address
-     * @return presentValue The present value
-     */
-    function getPresentValue(
-        bytes32 _ccy,
-        uint256 _maturity,
-        address _user
-    ) external view override returns (int256 presentValue) {
-        presentValue = FundManagementLogic
-            .calculateActualFunds(_ccy, _maturity, _user)
-            .presentValue;
-    }
-
-    /**
      * @notice Gets the total present value of the account for selected currency.
      * @param _ccy Currency name in bytes32 for Lending Market
      * @param _user User's address
@@ -409,6 +377,22 @@ contract LendingMarketController is
     }
 
     /**
+     * @notice Gets user's active position from the future value vault
+     * @param _ccy Currency name in bytes32
+     * @param _maturity The maturity of the selected market
+     * @param _user User's address
+     * @return presentValue The present value of the position
+     * @return futureValue The future value of the position
+     */
+    function getPosition(
+        bytes32 _ccy,
+        uint256 _maturity,
+        address _user
+    ) external view override returns (int256 presentValue, int256 futureValue) {
+        (presentValue, futureValue) = FundManagementLogic.getPosition(_ccy, _maturity, _user);
+    }
+
+    /**
      * @notice Gets user's active positions from the future value vaults
      * @param _ccys Currency name list in bytes32
      * @param _user User's address
@@ -418,7 +402,7 @@ contract LendingMarketController is
         external
         view
         override
-        returns (ILendingMarketController.Position[] memory positions)
+        returns (Position[] memory positions)
     {
         positions = FundManagementLogic.getPositions(_ccys, _user);
     }

--- a/contracts/protocol/interfaces/ILendingMarketController.sol
+++ b/contracts/protocol/interfaces/ILendingMarketController.sol
@@ -65,18 +65,6 @@ interface ILendingMarketController {
 
     function getUsedCurrencies(address user) external view returns (bytes32[] memory);
 
-    function getFutureValue(
-        bytes32 ccy,
-        uint256 maturity,
-        address user
-    ) external view returns (int256 futureValue);
-
-    function getPresentValue(
-        bytes32 ccy,
-        uint256 maturity,
-        address user
-    ) external view returns (int256 presentValue);
-
     function getTotalPresentValue(bytes32 ccy, address user) external view returns (int256);
 
     function getTotalPresentValueInBaseCurrency(address user)
@@ -91,10 +79,16 @@ interface ILendingMarketController {
         view
         returns (Order[] memory activeOrders, Order[] memory inactiveOrders);
 
+    function getPosition(
+        bytes32 _ccy,
+        uint256 _maturity,
+        address _user
+    ) external view returns (int256 presentValue, int256 futureValue);
+
     function getPositions(bytes32[] memory ccys, address user)
         external
         view
-        returns (ILendingMarketController.Position[] memory positions);
+        returns (Position[] memory positions);
 
     function calculateFunds(bytes32 ccy, address user)
         external

--- a/contracts/protocol/libraries/logics/FundManagementLogic.sol
+++ b/contracts/protocol/libraries/logics/FundManagementLogic.sol
@@ -709,18 +709,25 @@ library FundManagementLogic {
         positions = new ILendingMarketController.Position[](maturities.length);
 
         for (uint256 i; i < maturities.length; i++) {
-            FundManagementLogic.ActualFunds memory funds = calculateActualFunds(
-                _ccy,
-                maturities[i],
-                _user
-            );
+            (int256 presentValue, int256 futureValue) = getPosition(_ccy, maturities[i], _user);
+
             positions[i] = ILendingMarketController.Position(
                 _ccy,
                 maturities[i],
-                funds.presentValue,
-                funds.futureValue
+                presentValue,
+                futureValue
             );
         }
+    }
+
+    function getPosition(
+        bytes32 _ccy,
+        uint256 _maturity,
+        address _user
+    ) public view returns (int256 presentValue, int256 futureValue) {
+        FundManagementLogic.ActualFunds memory funds = calculateActualFunds(_ccy, _maturity, _user);
+        presentValue = funds.presentValue;
+        futureValue = funds.futureValue;
     }
 
     function cleanUpAllFunds(address _user) external {

--- a/test/integration/auto-rolls.test.ts
+++ b/test/integration/auto-rolls.test.ts
@@ -211,11 +211,12 @@ describe('Integration Test: Auto-rolls', async () => {
       const { futureValue: bobFV } = await futureValueVaults[0].getFutureValue(
         bob.address,
       );
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       expect(aliceFVBefore).to.equal('0');
       expect(bobFV).not.to.equal('0');
@@ -259,11 +260,12 @@ describe('Integration Test: Auto-rolls', async () => {
           8510,
         );
 
-      const aliceFVBefore = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceFVBefore } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       // Auto-roll
       await executeAutoRoll('8500');
@@ -273,19 +275,21 @@ describe('Integration Test: Auto-rolls', async () => {
       expect(carolCoverageAfter).to.equal('2000');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
       expect(aliceActualFV).to.equal('0');
 
       // Check future value * genesis value
-      const aliceFVAfter = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { futureValue: aliceFVAfter } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       const aliceGVAfter = await lendingMarketController.getGenesisValue(
         hexETH,
@@ -357,21 +361,23 @@ describe('Integration Test: Auto-rolls', async () => {
           8100,
         );
 
-      const aliceFVBefore = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceFVBefore } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       // Auto-roll
       await executeAutoRoll('8000');
 
       // Check future value
-      const aliceFVAfter = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { futureValue: aliceFVAfter } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       const { lendingCompoundFactor: lendingCF0 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[0]);
@@ -444,11 +450,12 @@ describe('Integration Test: Auto-rolls', async () => {
       await createSampleETHOrders(carol, maturities[0], '8000');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       expect(aliceActualFV).equal('125000000000000000');
     });
@@ -481,16 +488,18 @@ describe('Integration Test: Auto-rolls', async () => {
       await createSampleETHOrders(carol, maturities[1], '5000');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
-      const bobActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        bob.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
+      const { futureValue: bobActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          bob.address,
+        );
 
       const { timestamp } = await ethers.provider.getBlock(tx.blockHash);
       const fee = calculateOrderFee(
@@ -522,16 +531,12 @@ describe('Integration Test: Auto-rolls', async () => {
         [alice, bob].map(async (user) =>
           Promise.all([
             lendingMarketController.getTotalPresentValue(hexETH, user.address),
-            lendingMarketController.getPresentValue(
-              hexETH,
-              maturities[0],
-              user.address,
-            ),
-            lendingMarketController.getPresentValue(
-              hexETH,
-              maturities[1],
-              user.address,
-            ),
+            lendingMarketController
+              .getPosition(hexETH, maturities[0], user.address)
+              .then(({ presentValue }) => presentValue),
+            lendingMarketController
+              .getPosition(hexETH, maturities[1], user.address)
+              .then(({ presentValue }) => presentValue),
           ]),
         ),
       );
@@ -539,16 +544,18 @@ describe('Integration Test: Auto-rolls', async () => {
       const [aliceTotalPVBefore, alicePV0Before, alicePV1Before] = alicePVs;
       const [bobTotalPVBefore, bobPV0Before, bobPV1Before] = bobPVs;
 
-      const aliceFV0Before = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const aliceFV1Before = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { futureValue: aliceFV0Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { futureValue: aliceFV1Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       expect(alicePV0Before).equal(orderAmount);
       expect(aliceTotalPVBefore).to.equal(alicePV0Before.add(alicePV1Before));
@@ -560,37 +567,34 @@ describe('Integration Test: Auto-rolls', async () => {
       // Auto-roll
       await executeAutoRoll();
 
-      // Check present value
       const aliceTotalPVAfter =
         await lendingMarketController.getTotalPresentValue(
           hexETH,
           alice.address,
         );
-      const alicePV0After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { presentValue: alicePV0After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1After, futureValue: aliceFV1After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
-      expect(alicePV0After).to.equal('0');
-      expect(alicePV1After).to.equal(aliceTotalPVAfter);
-
-      // Check future value
       const { lendingCompoundFactor: lendingCF0 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[0]);
       const { lendingCompoundFactor: lendingCF1 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[1]);
-      const aliceFV1After = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
 
+      // Check present value
+      expect(alicePV0After).to.equal('0');
+      expect(alicePV1After).to.equal(aliceTotalPVAfter);
+
+      // Check future value
       expect(
         aliceFV1After
           .sub(
@@ -606,29 +610,33 @@ describe('Integration Test: Auto-rolls', async () => {
     });
 
     it('Clean orders', async () => {
-      const alicePV0Before = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1Before = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { presentValue: alicePV0Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       await lendingMarketController.cleanUpFunds(hexETH, alice.address);
 
-      const alicePV0After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { presentValue: alicePV0After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       expect(alicePV0Before).to.equal(alicePV0After);
       expect(alicePV1Before).to.equal(alicePV1After);
@@ -674,62 +682,63 @@ describe('Integration Test: Auto-rolls', async () => {
       await createSampleETHOrders(owner, maturities[1], '8333');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       expect(aliceActualFV).to.equal('1200048001920076803072');
     });
 
     for (let i = 0; i <= 9; i++) {
       it(`Execute auto-roll (${formatOrdinals(i + 1)} time)`, async () => {
-        const aliceFV0Before = await lendingMarketController.getFutureValue(
-          hexETH,
-          maturities[0],
-          alice.address,
-        );
-        const aliceFV1Before = await lendingMarketController.getFutureValue(
-          hexETH,
-          maturities[1],
-          alice.address,
-        );
+        const { futureValue: aliceFV0Before } =
+          await lendingMarketController.getPosition(
+            hexETH,
+            maturities[0],
+            alice.address,
+          );
+        const { futureValue: aliceFV1Before } =
+          await lendingMarketController.getPosition(
+            hexETH,
+            maturities[1],
+            alice.address,
+          );
 
         // Auto-roll
         await executeAutoRoll();
 
-        // Check present value
         const aliceTotalPVAfter =
           await lendingMarketController.getTotalPresentValue(
             hexETH,
             alice.address,
           );
-        const alicePV0After = await lendingMarketController.getPresentValue(
-          hexETH,
-          maturities[0],
-          alice.address,
-        );
-        const alicePV1After = await lendingMarketController.getPresentValue(
-          hexETH,
-          maturities[1],
-          alice.address,
-        );
 
-        expect(alicePV0After).to.equal('0');
-        expect(alicePV1After).to.equal(aliceTotalPVAfter);
+        const { presentValue: alicePV0After } =
+          await lendingMarketController.getPosition(
+            hexETH,
+            maturities[0],
+            alice.address,
+          );
+        const { presentValue: alicePV1After, futureValue: aliceFV1After } =
+          await lendingMarketController.getPosition(
+            hexETH,
+            maturities[1],
+            alice.address,
+          );
 
-        // Check future value
         const { lendingCompoundFactor: lendingCF0 } =
           await genesisValueVault.getAutoRollLog(hexETH, maturities[0]);
         const { lendingCompoundFactor: lendingCF1 } =
           await genesisValueVault.getAutoRollLog(hexETH, maturities[1]);
-        const aliceFV1After = await lendingMarketController.getFutureValue(
-          hexETH,
-          maturities[1],
-          alice.address,
-        );
 
+        // Check present value
+        expect(alicePV0After).to.equal('0');
+        expect(alicePV1After).to.equal(aliceTotalPVAfter);
+
+        // Check future value
         expect(
           aliceFV1After
             .sub(
@@ -793,11 +802,12 @@ describe('Integration Test: Auto-rolls', async () => {
       ).to.emit(lendingMarkets[0], 'OrdersTaken');
 
       // Check present value
-      const daveActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        dave.address,
-      );
+      const { futureValue: daveActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          dave.address,
+        );
 
       const midUnitPrice = await lendingMarkets[0].getMidUnitPrice();
       const davePV = await lendingMarketController.getTotalPresentValue(
@@ -910,38 +920,43 @@ describe('Integration Test: Auto-rolls', async () => {
       ).to.emit(lendingMarkets[0], 'OrdersTaken');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
 
       expect(aliceActualFV).to.equal('125000000000000000');
     });
 
     it('Advance time', async () => {
-      const alicePV0Before = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1Before = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { presentValue: alicePV0Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       await time.increaseTo(maturities[0].toString());
-      const alicePV0After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { presentValue: alicePV0After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       expect(alicePV0Before).to.equal(alicePV0After);
       expect(alicePV1Before).to.equal(alicePV1After);
@@ -965,16 +980,18 @@ describe('Integration Test: Auto-rolls', async () => {
     });
 
     it(`Execute auto-roll`, async () => {
-      const aliceFV0Before = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const aliceFV1Before = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
+      const { futureValue: aliceFV0Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { futureValue: aliceFV1Before } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
       // Auto-roll
       await createSampleETHOrders(carol, maturities[1], '8000');
@@ -986,37 +1003,35 @@ describe('Integration Test: Auto-rolls', async () => {
         maturities[maturities.length - 1],
       );
 
-      // Check present value
       const aliceTotalPVAfter =
         await lendingMarketController.getTotalPresentValue(
           hexETH,
           alice.address,
         );
-      const alicePV0After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[0],
-        alice.address,
-      );
-      const alicePV1After = await lendingMarketController.getPresentValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
 
-      expect(alicePV0After).to.equal('0');
-      expect(alicePV1After).to.equal(aliceTotalPVAfter);
+      const { presentValue: alicePV0After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[0],
+          alice.address,
+        );
+      const { presentValue: alicePV1After, futureValue: aliceFV1After } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[1],
+          alice.address,
+        );
 
-      // Check future value
       const { lendingCompoundFactor: lendingCF0 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[0]);
       const { lendingCompoundFactor: lendingCF1 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[1]);
-      const aliceFV1After = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[1],
-        alice.address,
-      );
 
+      // Check present value
+      expect(alicePV0After).to.equal('0');
+      expect(alicePV1After).to.equal(aliceTotalPVAfter);
+
+      // Check future value
       expect(
         aliceFV1After
           .sub(

--- a/test/integration/deposit.test.ts
+++ b/test/integration/deposit.test.ts
@@ -9,6 +9,7 @@ import {
   LIQUIDATION_PROTOCOL_FEE_RATE,
   LIQUIDATION_THRESHOLD_RATE,
   LIQUIDATOR_FEE_RATE,
+  PRICE_DIGIT,
   btcToETHRate,
   eFilToETHRate,
   wBtcToBTCRate,
@@ -590,12 +591,13 @@ describe('Integration Test: Deposit', async () => {
 
       const coverage = await tokenVault.getCoverage(alice.address);
 
-      const aliceFV = await lendingMarketController.getFutureValue(
-        hexWBTC,
-        wBTCMaturities[0],
-        alice.address,
-      );
-      const bobFV = await lendingMarketController.getFutureValue(
+      const { futureValue: aliceFV } =
+        await lendingMarketController.getPosition(
+          hexWBTC,
+          wBTCMaturities[0],
+          alice.address,
+        );
+      const { futureValue: bobFV } = await lendingMarketController.getPosition(
         hexWBTC,
         wBTCMaturities[0],
         bob.address,
@@ -643,12 +645,13 @@ describe('Integration Test: Deposit', async () => {
         );
 
       const coverage = await tokenVault.getCoverage(alice.address);
-      const aliceFV = await lendingMarketController.getFutureValue(
-        hexEFIL,
-        filMaturities[0],
-        alice.address,
-      );
-      const bobFV = await lendingMarketController.getFutureValue(
+      const { futureValue: aliceFV } =
+        await lendingMarketController.getPosition(
+          hexEFIL,
+          filMaturities[0],
+          alice.address,
+        );
+      const { futureValue: bobFV } = await lendingMarketController.getPosition(
         hexEFIL,
         filMaturities[0],
         bob.address,
@@ -745,12 +748,13 @@ describe('Integration Test: Deposit', async () => {
         .createOrder(hexEFIL, filMaturities[0], Side.BORROW, orderAmount, '0');
 
       const coverage = await tokenVault.getCoverage(alice.address);
-      const aliceFV = await lendingMarketController.getFutureValue(
-        hexEFIL,
-        filMaturities[0],
-        alice.address,
-      );
-      const bobFV = await lendingMarketController.getFutureValue(
+      const { futureValue: aliceFV, presentValue: alicePV } =
+        await lendingMarketController.getPosition(
+          hexEFIL,
+          filMaturities[0],
+          alice.address,
+        );
+      const { futureValue: bobFV } = await lendingMarketController.getPosition(
         hexEFIL,
         filMaturities[0],
         bob.address,
@@ -763,7 +767,11 @@ describe('Integration Test: Deposit', async () => {
         filMaturities[0].sub(timestamp),
       );
 
-      expect(coverage.sub('4010').abs()).lte(1);
+      expect(
+        coverage
+          .sub(alicePV.abs().mul(PRICE_DIGIT).div(orderAmount.mul(5).div(2)))
+          .abs(),
+      ).lte(1);
       expect(bobFV.add(aliceFV).add(fee).abs()).to.lte(1);
     });
 
@@ -876,12 +884,13 @@ describe('Integration Test: Deposit', async () => {
         );
 
       const coverage = await tokenVault.getCoverage(alice.address);
-      const aliceFV = await lendingMarketController.getFutureValue(
-        hexEFIL,
-        filMaturities[0],
-        alice.address,
-      );
-      const bobFV = await lendingMarketController.getFutureValue(
+      const { futureValue: aliceFV } =
+        await lendingMarketController.getPosition(
+          hexEFIL,
+          filMaturities[0],
+          alice.address,
+        );
+      const { futureValue: bobFV } = await lendingMarketController.getPosition(
         hexEFIL,
         filMaturities[0],
         bob.address,
@@ -925,12 +934,13 @@ describe('Integration Test: Deposit', async () => {
         .connect(alice)
         .createOrder(hexETH, ethMaturities[0], Side.LEND, orderAmount, '0');
 
-      const aliceFV = await lendingMarketController.getFutureValue(
-        hexETH,
-        ethMaturities[0],
-        alice.address,
-      );
-      const bobFV = await lendingMarketController.getFutureValue(
+      const { futureValue: aliceFV } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          ethMaturities[0],
+          alice.address,
+        );
+      const { futureValue: bobFV } = await lendingMarketController.getPosition(
         hexETH,
         ethMaturities[0],
         bob.address,

--- a/test/integration/itayose.test.ts
+++ b/test/integration/itayose.test.ts
@@ -410,11 +410,12 @@ describe('Integration Test: Itayose', async () => {
     it('Check if clearing order process takes the opening price into accounts', async () => {
       const lendingMarket = lendingMarkets[lendingMarkets.length - 1];
       // Fetch the future value before the clean up process is called
-      const daveFVBefore = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[maturities.length - 1],
-        dave.address,
-      );
+      const { futureValue: daveFVBefore } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[maturities.length - 1],
+          dave.address,
+        );
 
       // inactive order will be cleaned up which affects the future value of dave
       await lendingMarketController
@@ -431,11 +432,12 @@ describe('Integration Test: Itayose', async () => {
         );
 
       // Fetch the future value after the clean up process was called
-      const daveFVAfter = await lendingMarketController.getFutureValue(
-        hexETH,
-        maturities[maturities.length - 1],
-        dave.address,
-      );
+      const { futureValue: daveFVAfter } =
+        await lendingMarketController.getPosition(
+          hexETH,
+          maturities[maturities.length - 1],
+          dave.address,
+        );
 
       // Fetch the opening unit price decided by Itayose
       const openingUnitPrice = await lendingMarket.getOpeningUnitPrice();

--- a/test/integration/liquidations.test.ts
+++ b/test/integration/liquidations.test.ts
@@ -82,11 +82,9 @@ describe('Integration Test: Liquidations', async () => {
           tokenVault.getDepositAmount(this.address, hexETH),
           tokenVault.getDepositAmount(this.address, hexUSDC),
           ...Object.entries(maturities).map(([key, maturity]) =>
-            lendingMarketController.getPresentValue(
-              getCcy(key.split('-')[0]),
-              maturity,
-              this.address,
-            ),
+            lendingMarketController
+              .getPosition(getCcy(key.split('-')[0]), maturity, this.address)
+              .then(({ presentValue }) => presentValue),
           ),
         ]);
 
@@ -589,8 +587,8 @@ describe('Integration Test: Liquidations', async () => {
           eFilToETHRate.mul('115').div('100'),
         );
 
-        const rfFutureValueBefore =
-          await lendingMarketController.getFutureValue(
+        const { futureValue: rfFutureValueBefore } =
+          await lendingMarketController.getPosition(
             hexEFIL,
             filMaturities[0],
             reserveFund.address,
@@ -610,11 +608,12 @@ describe('Integration Test: Liquidations', async () => {
           ),
         ).to.emit(fundManagementLogic, 'LiquidationExecuted');
 
-        const rfFutureValueAfter = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          reserveFund.address,
-        );
+        const { futureValue: rfFutureValueAfter } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            reserveFund.address,
+          );
         const tokenVaultBalanceAfter = await wETHToken.balanceOf(
           tokenVault.address,
         );
@@ -927,8 +926,8 @@ describe('Integration Test: Liquidations', async () => {
         });
         lendingInfo.show();
 
-        const liquidatorFutureValue =
-          await lendingMarketController.getFutureValue(
+        const { futureValue: liquidatorFutureValue } =
+          await lendingMarketController.getPosition(
             hexEFIL,
             filMaturities[0],
             liquidator.address,

--- a/test/integration/order-book.test.ts
+++ b/test/integration/order-book.test.ts
@@ -180,11 +180,9 @@ describe('Integration Test: Order Book', async () => {
 
         const [aliceFV, bobFV] = await Promise.all(
           [alice, bob].map(({ address }) =>
-            lendingMarketController.getFutureValue(
-              hexETH,
-              ethMaturities[0],
-              address,
-            ),
+            lendingMarketController
+              .getPosition(hexETH, ethMaturities[0], address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -224,11 +222,12 @@ describe('Integration Test: Order Book', async () => {
             .unwindPosition(hexETH, ethMaturities[0]),
         ).to.emit(fundManagementLogic, 'OrderFilled');
 
-        const aliceFV = await lendingMarketController.getFutureValue(
-          hexETH,
-          ethMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketController.getPosition(
+            hexETH,
+            ethMaturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal(0);
       });
@@ -301,11 +300,9 @@ describe('Integration Test: Order Book', async () => {
 
         const [aliceFV, bobFV] = await Promise.all(
           [alice, bob].map(({ address }) =>
-            lendingMarketController.getFutureValue(
-              hexEFIL,
-              filMaturities[0],
-              address,
-            ),
+            lendingMarketController
+              .getPosition(hexEFIL, filMaturities[0], address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -360,11 +357,12 @@ describe('Integration Test: Order Book', async () => {
             .unwindPosition(hexEFIL, filMaturities[0]),
         ).to.emit(fundManagementLogic, 'OrderFilled');
 
-        const aliceFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal(0);
       });
@@ -436,11 +434,9 @@ describe('Integration Test: Order Book', async () => {
 
         const [aliceFV, bobFV] = await Promise.all(
           [alice, bob].map(({ address }) =>
-            lendingMarketController.getFutureValue(
-              hexEFIL,
-              filMaturities[0],
-              address,
-            ),
+            lendingMarketController
+              .getPosition(hexEFIL, filMaturities[0], address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -449,11 +445,12 @@ describe('Integration Test: Order Book', async () => {
       });
 
       it('Check lending position', async () => {
-        const bobFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          bob.address,
-        );
+        const { futureValue: bobFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            bob.address,
+          );
 
         expect(bobFV).to.equal(calculateFutureValue(orderAmount, '8000'));
       });
@@ -479,11 +476,12 @@ describe('Integration Test: Order Book', async () => {
 
         await expect(tx).to.emit(fundManagementLogic, 'OrderFilled');
 
-        const bobFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          bob.address,
-        );
+        const { futureValue: bobFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            bob.address,
+          );
 
         expect(bobFV).to.equal(0);
 
@@ -575,11 +573,9 @@ describe('Integration Test: Order Book', async () => {
 
         const [aliceFV, bobFV] = await Promise.all(
           [alice, bob].map(({ address }) =>
-            lendingMarketController.getFutureValue(
-              hexEFIL,
-              filMaturities[0],
-              address,
-            ),
+            lendingMarketController
+              .getPosition(hexEFIL, filMaturities[0], address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -614,11 +610,9 @@ describe('Integration Test: Order Book', async () => {
 
         const [aliceFV, bobFV] = await Promise.all(
           [alice, bob].map(({ address }) =>
-            lendingMarketController.getFutureValue(
-              hexETH,
-              ethMaturities[0],
-              address,
-            ),
+            lendingMarketController
+              .getPosition(hexETH, ethMaturities[0], address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -670,11 +664,12 @@ describe('Integration Test: Order Book', async () => {
       });
 
       it('Unwind orders partially', async () => {
-        const aliceFVBefore = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFVBefore } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            alice.address,
+          );
 
         await tokenVault.connect(dave).deposit(hexETH, depositAmount.mul(2), {
           value: depositAmount.mul(2),
@@ -696,11 +691,12 @@ describe('Integration Test: Order Book', async () => {
             .unwindPosition(hexEFIL, filMaturities[0]),
         ).to.emit(fundManagementLogic, 'OrderFilled');
 
-        const aliceFVAfter = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFVAfter } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            alice.address,
+          );
 
         expect(aliceFVAfter.abs()).to.lte(aliceFVBefore.abs());
       });
@@ -774,11 +770,12 @@ describe('Integration Test: Order Book', async () => {
           filMaturities[0].sub(timestamp),
         );
 
-        const bobFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          bob.address,
-        );
+        const { futureValue: bobFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            bob.address,
+          );
 
         calculateFutureValue(orderAmount.div(2), 8000);
 
@@ -981,11 +978,9 @@ describe('Integration Test: Order Book', async () => {
         it(`Check orders`, async () => {
           const [aliceFV, bobFV] = await Promise.all(
             [alice, bob].map(({ address }) =>
-              lendingMarketController.getFutureValue(
-                hexEFIL,
-                filMaturities[1],
-                address,
-              ),
+              lendingMarketController
+                .getPosition(hexEFIL, filMaturities[1], address)
+                .then(({ futureValue }) => futureValue),
             ),
           );
           const { activeOrderIds: borrowOrderIds } =
@@ -1056,11 +1051,9 @@ describe('Integration Test: Order Book', async () => {
         it(`Check orders`, async () => {
           const [aliceFV, bobFV] = await Promise.all(
             [alice, bob].map(({ address }) =>
-              lendingMarketController.getFutureValue(
-                hexEFIL,
-                filMaturities[1],
-                address,
-              ),
+              lendingMarketController
+                .getPosition(hexEFIL, filMaturities[1], address)
+                .then(({ futureValue }) => futureValue),
             ),
           );
 
@@ -1149,11 +1142,9 @@ describe('Integration Test: Order Book', async () => {
         it(`Check orders`, async () => {
           const [aliceFV, bobFV] = await Promise.all(
             [alice, bob].map(({ address }) =>
-              lendingMarketController.getFutureValue(
-                hexEFIL,
-                filMaturities[1],
-                address,
-              ),
+              lendingMarketController
+                .getPosition(hexEFIL, filMaturities[1], address)
+                .then(({ futureValue }) => futureValue),
             ),
           );
 
@@ -1212,11 +1203,12 @@ describe('Integration Test: Order Book', async () => {
             '8000',
           );
 
-        const aliceFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            alice.address,
+          );
         const unusedCollateral = await tokenVault.getUnusedCollateral(
           alice.address,
         );
@@ -1304,11 +1296,12 @@ describe('Integration Test: Order Book', async () => {
           alice.address,
           hexETH,
         );
-        const aliceFV = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          filMaturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            filMaturities[0],
+            alice.address,
+          );
         const unusedCollateral = await tokenVault.getUnusedCollateral(
           alice.address,
         );

--- a/test/performance/auto-rolls.test.ts
+++ b/test/performance/auto-rolls.test.ts
@@ -173,27 +173,30 @@ describe('Performance Test: Auto-rolls', async () => {
       ).to.emit(lendingMarkets[0], 'OrdersTaken');
 
       // Check future value
-      const aliceActualFV = await lendingMarketController.getFutureValue(
-        hexEFIL,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceActualFV } =
+        await lendingMarketController.getPosition(
+          hexEFIL,
+          maturities[0],
+          alice.address,
+        );
 
       expect(aliceActualFV.sub('1250000000000000000000000').abs()).lte(1);
     });
 
     for (let i = 0; i < 800; i++) {
       it(`Execute auto-roll (${formatOrdinals(i + 1)} time)`, async () => {
-        const aliceFV0Before = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          maturities[0],
-          alice.address,
-        );
-        const aliceFV1Before = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          maturities[1],
-          alice.address,
-        );
+        const { futureValue: aliceFV0Before } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            maturities[0],
+            alice.address,
+          );
+        const { futureValue: aliceFV1Before } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            maturities[1],
+            alice.address,
+          );
 
         // Auto-roll
         await createSampleFILOrders(carol, maturities[1], '9523');
@@ -206,38 +209,35 @@ describe('Performance Test: Auto-rolls', async () => {
           maturities[maturities.length - 1],
         );
 
-        // Check present value
         const aliceTotalPVAfter =
           await lendingMarketController.getTotalPresentValue(
             hexEFIL,
             alice.address,
           );
-        const alicePV0After = await lendingMarketController.getPresentValue(
-          hexEFIL,
-          maturities[0],
-          alice.address,
-        );
-        const alicePV1After = await lendingMarketController.getPresentValue(
-          hexEFIL,
-          maturities[1],
-          alice.address,
-        );
+
+        const { lendingCompoundFactor: lendingCF0 } =
+          await genesisValueVault.getAutoRollLog(hexEFIL, maturities[0]);
+        const { lendingCompoundFactor: lendingCF1 } =
+          await genesisValueVault.getAutoRollLog(hexEFIL, maturities[1]);
+
+        const { futureValue: alicePV0After } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            maturities[0],
+            alice.address,
+          );
+        const { futureValue: aliceFV1After, presentValue: alicePV1After } =
+          await lendingMarketController.getPosition(
+            hexEFIL,
+            maturities[1],
+            alice.address,
+          );
 
         // Check present value
         expect(alicePV0After).to.equal('0');
         expect(alicePV1After).to.equal(aliceTotalPVAfter);
 
         // Check future value
-        const { lendingCompoundFactor: lendingCF0 } =
-          await genesisValueVault.getAutoRollLog(hexEFIL, maturities[0]);
-        const { lendingCompoundFactor: lendingCF1 } =
-          await genesisValueVault.getAutoRollLog(hexEFIL, maturities[1]);
-        const aliceFV1After = await lendingMarketController.getFutureValue(
-          hexEFIL,
-          maturities[1],
-          alice.address,
-        );
-
         expect(
           aliceFV1After
             .sub(
@@ -275,11 +275,12 @@ describe('Performance Test: Auto-rolls', async () => {
       ).to.emit(lendingMarkets[0], 'OrdersTaken');
 
       // Check future value
-      const ellenActualFV = await lendingMarketController.getFutureValue(
-        hexEFIL,
-        maturities[0],
-        ellen.address,
-      );
+      const { futureValue: ellenActualFV } =
+        await lendingMarketController.getPosition(
+          hexEFIL,
+          maturities[0],
+          ellen.address,
+        );
 
       expect(ellenActualFV).to.equal('1050089257586894886065316');
     });

--- a/test/unit/lending-market-controller/itayose.test.ts
+++ b/test/unit/lending-market-controller/itayose.test.ts
@@ -334,11 +334,13 @@ describe('LendingMarketController - Itayose', () => {
 
       const [aliceFV, bobFV, carolFV] = await Promise.all(
         [alice, bob, carol].map((account) =>
-          lendingMarketControllerProxy.getFutureValue(
-            targetCurrency,
-            maturities[maturities.length - 1],
-            account.address,
-          ),
+          lendingMarketControllerProxy
+            .getPosition(
+              targetCurrency,
+              maturities[maturities.length - 1],
+              account.address,
+            )
+            .then(({ futureValue }) => futureValue),
         ),
       );
 
@@ -409,11 +411,12 @@ describe('LendingMarketController - Itayose', () => {
       const openingPrice = await lendingMarket.getOpeningUnitPrice();
       expect(openingPrice).to.equal('7500');
 
-      const carolFVBefore = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturity,
-        carol.address,
-      );
+      const { futureValue: carolFVBefore } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturity,
+          carol.address,
+        );
 
       expect(carolFVBefore).to.equal('0');
 
@@ -429,11 +432,12 @@ describe('LendingMarketController - Itayose', () => {
           ),
       ).to.emit(lendingMarket, 'OrdersTaken');
 
-      const carolFVAfter = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturity,
-        carol.address,
-      );
+      const { futureValue: carolFVAfter } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturity,
+          carol.address,
+        );
 
       expect(carolFVAfter).to.equal('-375000000000000');
     });
@@ -496,11 +500,12 @@ describe('LendingMarketController - Itayose', () => {
       const openingPrice = await lendingMarket.getOpeningUnitPrice();
       expect(openingPrice).to.equal('8000');
 
-      const bobFVBefore = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturity,
-        bob.address,
-      );
+      const { futureValue: bobFVBefore } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturity,
+          bob.address,
+        );
 
       expect(bobFVBefore).to.equal('125000000000000');
 
@@ -516,11 +521,12 @@ describe('LendingMarketController - Itayose', () => {
           ),
       ).to.emit(lendingMarket, 'OrdersTaken');
 
-      const bobFVAfter = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturity,
-        bob.address,
-      );
+      const { futureValue: bobFVAfter } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturity,
+          bob.address,
+        );
 
       expect(bobFVAfter).to.equal('250000000000000');
     });

--- a/test/unit/lending-market-controller/orders.test.ts
+++ b/test/unit/lending-market-controller/orders.test.ts
@@ -464,21 +464,17 @@ describe('LendingMarketController - Orders', () => {
 
         const futureValues0 = await Promise.all(
           accounts.map((account) =>
-            lendingMarketControllerProxy.getFutureValue(
-              targetCurrency,
-              maturities[0],
-              account.address,
-            ),
+            lendingMarketControllerProxy
+              .getPosition(targetCurrency, maturities[0], account.address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
         const futureValues1 = await Promise.all(
           accounts.map((account) =>
-            lendingMarketControllerProxy.getFutureValue(
-              targetCurrency,
-              maturities[1],
-              account.address,
-            ),
+            lendingMarketControllerProxy
+              .getPosition(targetCurrency, maturities[1], account.address)
+              .then(({ futureValue }) => futureValue),
           ),
         );
 
@@ -1232,11 +1228,9 @@ describe('LendingMarketController - Orders', () => {
           );
         const alicePVs = await Promise.all(
           [0, 1, 2].map((marketNo) =>
-            lendingMarketControllerProxy.getPresentValue(
-              targetCurrency,
-              maturities[marketNo],
-              alice.address,
-            ),
+            lendingMarketControllerProxy
+              .getPosition(targetCurrency, maturities[marketNo], alice.address)
+              .then(({ presentValue }) => presentValue),
           ),
         );
         const totalPresentValues = {
@@ -1569,11 +1563,12 @@ describe('LendingMarketController - Orders', () => {
         alice.address,
       );
 
-      const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          alice.address,
+        );
 
       const totalFV = await futureValueVaults[0].getTotalSupply(maturities[0]);
 
@@ -1596,16 +1591,18 @@ describe('LendingMarketController - Orders', () => {
         alice.address,
       );
 
-      const aliceFV2 = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        alice.address,
-      );
-      const carolFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        carol.address,
-      );
+      const { futureValue: aliceFV2 } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          alice.address,
+        );
+      const { futureValue: carolFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          carol.address,
+        );
       const totalFV2 = await futureValueVaults[0].getTotalSupply(maturities[0]);
 
       expect(aliceFV2.add(carolFV).abs()).to.equal(totalFV2);
@@ -1649,19 +1646,20 @@ describe('LendingMarketController - Orders', () => {
         alice.address,
       );
 
-      const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        alice.address,
-      );
+      const { futureValue: aliceFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          alice.address,
+        );
       const totalFV = await futureValueVaults[0].getTotalSupply(maturities[0]);
 
       expect(aliceFV.abs()).to.equal(totalFV);
     });
 
     it('Fill borrowing orders including own order', async () => {
-      const reserveFundFVBefore =
-        await lendingMarketControllerProxy.getFutureValue(
+      const { futureValue: reserveFundFVBefore } =
+        await lendingMarketControllerProxy.getPosition(
           targetCurrency,
           maturities[0],
           mockReserveFund.address,
@@ -1704,13 +1702,14 @@ describe('LendingMarketController - Orders', () => {
         alice.address,
       );
 
-      const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        alice.address,
-      );
-      const reserveFundFVAfter =
-        await lendingMarketControllerProxy.getFutureValue(
+      const { futureValue: aliceFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          alice.address,
+        );
+      const { futureValue: reserveFundFVAfter } =
+        await lendingMarketControllerProxy.getPosition(
           targetCurrency,
           maturities[0],
           mockReserveFund.address,
@@ -1782,16 +1781,18 @@ describe('LendingMarketController - Orders', () => {
         alice.address,
       );
 
-      const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        alice.address,
-      );
-      const carolFV = await lendingMarketControllerProxy.getFutureValue(
-        targetCurrency,
-        maturities[0],
-        carol.address,
-      );
+      const { futureValue: aliceFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          alice.address,
+        );
+      const { futureValue: carolFV } =
+        await lendingMarketControllerProxy.getPosition(
+          targetCurrency,
+          maturities[0],
+          carol.address,
+        );
       const totalFV = await futureValueVaults[0].getTotalSupply(maturities[0]);
 
       expect(aliceFV.abs()).to.equal(0);
@@ -2483,11 +2484,12 @@ describe('LendingMarketController - Orders', () => {
             ),
           );
 
-        const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-          targetCurrency,
-          maturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketControllerProxy.getPosition(
+            targetCurrency,
+            maturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal('0');
       });
@@ -2561,11 +2563,12 @@ describe('LendingMarketController - Orders', () => {
             ),
           );
 
-        const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-          targetCurrency,
-          maturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketControllerProxy.getPosition(
+            targetCurrency,
+            maturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal('0');
       });
@@ -2627,11 +2630,12 @@ describe('LendingMarketController - Orders', () => {
             ),
           );
 
-        const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-          targetCurrency,
-          maturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketControllerProxy.getPosition(
+            targetCurrency,
+            maturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal('1250000000000000');
       });
@@ -2667,11 +2671,12 @@ describe('LendingMarketController - Orders', () => {
             .unwindPosition(targetCurrency, maturities[0]),
         ).to.be.revertedWith('Order not found');
 
-        const aliceFV = await lendingMarketControllerProxy.getFutureValue(
-          targetCurrency,
-          maturities[0],
-          alice.address,
-        );
+        const { futureValue: aliceFV } =
+          await lendingMarketControllerProxy.getPosition(
+            targetCurrency,
+            maturities[0],
+            alice.address,
+          );
 
         expect(aliceFV).to.equal('-12500000000000000');
       });

--- a/test/unit/lending-market-controller/terminations.test.ts
+++ b/test/unit/lending-market-controller/terminations.test.ts
@@ -261,13 +261,12 @@ describe('LendingMarketController - Terminations', () => {
           alice.address,
         ),
       ).to.equal('-50000000000000000');
-      expect(
-        await lendingMarketControllerProxy.getFutureValue(
-          targetCurrency,
-          maturities[0],
-          alice.address,
-        ),
-      ).to.equal('-62500000000000000');
+
+      await lendingMarketControllerProxy
+        .getPosition(targetCurrency, maturities[0], alice.address)
+        .then(({ futureValue }) =>
+          expect(futureValue).to.equal('-62500000000000000'),
+        );
 
       await expect(
         lendingMarketControllerProxy.executeEmergencyTermination(),
@@ -286,13 +285,9 @@ describe('LendingMarketController - Terminations', () => {
             user.address,
           ),
         ).to.equal('0');
-        expect(
-          await lendingMarketControllerProxy.getFutureValue(
-            targetCurrency,
-            maturities[0],
-            user.address,
-          ),
-        ).to.equal('0');
+        await lendingMarketControllerProxy
+          .getPosition(targetCurrency, maturities[0], user.address)
+          .then(({ futureValue }) => expect(futureValue).to.equal('0'));
       }
     });
 


### PR DESCRIPTION
- Add the `getPositions` function to get active positions per user.
- Remove the functions`getFutureValue` & `getPresentValue`, and add the `getPosition` function to get active position including the future value and the present value instead in terms of consistency.
- Fix test code.