### PR TITLE
refactor: refactor storage [SF-625]

### DIFF
--- a/contracts/protocol/LendingMarket.sol
+++ b/contracts/protocol/LendingMarket.sol
@@ -121,7 +121,10 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
                 borrowUnitPrice: OrderBookLogic.getLowestBorrowingUnitPrice(),
                 lendUnitPrice: OrderBookLogic.getHighestLendingUnitPrice(),
                 midUnitPrice: getMidUnitPrice(),
-                openingUnitPrice: Storage.slot().openingUnitPrices[Storage.slot().maturity],
+                openingUnitPrice: Storage
+                    .slot()
+                    .itayoseLogs[Storage.slot().maturity]
+                    .openingUnitPrice,
                 isReady: isReady()
             });
     }
@@ -210,14 +213,6 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
      */
     function getOpeningDate() external view override returns (uint256 openingDate) {
         return Storage.slot().openingDate;
-    }
-
-    /**
-     * @notice Gets the market opening unit price.
-     * @return openingUnitPrices The market opening unit price
-     */
-    function getOpeningUnitPrice() external view override returns (uint256 openingUnitPrices) {
-        return Storage.slot().openingUnitPrices[Storage.slot().maturity];
     }
 
     /**
@@ -756,8 +751,8 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
         }
 
         Storage.slot().isReady[Storage.slot().maturity] = true;
-        Storage.slot().openingUnitPrices[Storage.slot().maturity] = openingUnitPrice;
         Storage.slot().itayoseLogs[Storage.slot().maturity] = ItayoseLog(
+            openingUnitPrice,
             lastLendUnitPrice,
             lastBorrowUnitPrice
         );

--- a/contracts/protocol/interfaces/ILendingMarket.sol
+++ b/contracts/protocol/interfaces/ILendingMarket.sol
@@ -144,8 +144,6 @@ interface ILendingMarket {
 
     function getOpeningDate() external view returns (uint256);
 
-    function getOpeningUnitPrice() external view returns (uint256);
-
     function isReady() external view returns (bool);
 
     function isMatured() external view returns (bool);

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -6,7 +6,7 @@ import {Constants} from "../Constants.sol";
 import {RoundingUint256} from "../math/RoundingUint256.sol";
 import {ILendingMarket} from "../../interfaces/ILendingMarket.sol";
 import {ProtocolTypes} from "../../types/ProtocolTypes.sol";
-import {LendingMarketStorage as Storage, MarketOrder} from "../../storages/LendingMarketStorage.sol";
+import {LendingMarketStorage as Storage, MarketOrder, ItayoseLog} from "../../storages/LendingMarketStorage.sol";
 
 library OrderBookLogic {
     using OrderStatisticsTreeLib for OrderStatisticsTreeLib.Tree;
@@ -713,12 +713,11 @@ library OrderBookLogic {
         uint256 unitPrice = marketOrder.unitPrice;
 
         if (Storage.slot().isPreOrder[_orderId]) {
-            uint256 openingUnitPrice = Storage.slot().openingUnitPrices[marketOrder.maturity];
-            uint256 lastLendUnitPrice = Storage
-                .slot()
-                .itayoseLogs[marketOrder.maturity]
-                .lastLendUnitPrice;
-            unitPrice = lastLendUnitPrice <= unitPrice ? openingUnitPrice : unitPrice;
+            ItayoseLog memory itayoseLog = Storage.slot().itayoseLogs[marketOrder.maturity];
+
+            unitPrice = itayoseLog.lastLendUnitPrice <= unitPrice
+                ? itayoseLog.openingUnitPrice
+                : unitPrice;
         }
 
         presentValue = orderItem.amount;
@@ -738,12 +737,11 @@ library OrderBookLogic {
         uint256 unitPrice = marketOrder.unitPrice;
 
         if (Storage.slot().isPreOrder[_orderId]) {
-            uint256 openingUnitPrice = Storage.slot().openingUnitPrices[marketOrder.maturity];
-            uint256 lastBorrowUnitPrice = Storage
-                .slot()
-                .itayoseLogs[marketOrder.maturity]
-                .lastBorrowUnitPrice;
-            unitPrice = lastBorrowUnitPrice >= unitPrice ? openingUnitPrice : unitPrice;
+            ItayoseLog memory itayoseLog = Storage.slot().itayoseLogs[marketOrder.maturity];
+
+            unitPrice = itayoseLog.lastBorrowUnitPrice >= unitPrice
+                ? itayoseLog.openingUnitPrice
+                : unitPrice;
         }
 
         presentValue = orderItem.amount;

--- a/contracts/protocol/storages/LendingMarketConfigurationStorage.sol
+++ b/contracts/protocol/storages/LendingMarketConfigurationStorage.sol
@@ -7,8 +7,6 @@ library LendingMarketConfigurationStorage {
     struct Storage {
         // Mapping from currency to order fee rate received by protocol (in basis point)
         mapping(bytes32 => uint256) orderFeeRates;
-        // Mapping from currency to auto-roll fee rate received by protocol (in basis point)
-        mapping(bytes32 => uint256) autoRollFeeRates; // TODO: remove this when forced deployment is executed
         // Mapping from currency to rate limit range of yield for the circuit breaker
         mapping(bytes32 => uint256) circuitBreakerLimitRanges;
         // The period to calculate the volume-weighted average price of transactions to use as auto-roll fee rate.

--- a/contracts/protocol/storages/LendingMarketStorage.sol
+++ b/contracts/protocol/storages/LendingMarketStorage.sol
@@ -12,6 +12,7 @@ struct MarketOrder {
 }
 
 struct ItayoseLog {
+    uint256 openingUnitPrice;
     uint256 lastLendUnitPrice;
     uint256 lastBorrowUnitPrice;
 }
@@ -26,8 +27,6 @@ library LendingMarketStorage {
         uint48 lastOrderId;
         uint256 openingDate;
         uint256 maturity;
-        // Mapping from maturity to opening unit price
-        mapping(uint256 => uint256) openingUnitPrices; // TODO: Merge with itayoseLogs when executing forced deployment
         // Mapping from maturity to boolean if the market is ready or not
         mapping(uint256 => bool) isReady;
         // Mapping from user to active lend order ids

--- a/test/integration/itayose.test.ts
+++ b/test/integration/itayose.test.ts
@@ -354,7 +354,9 @@ describe('Integration Test: Itayose', async () => {
         maturities[maturities.length - 1],
       );
       const marketInfo = await lendingMarket.getMarket();
-      const openingUnitPrice = await lendingMarket.getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarket.getItayoseLog(
+        maturities[maturities.length - 1],
+      );
 
       expect(await lendingMarket.isOpened()).to.true;
       expect(marketInfo.openingDate).to.equal(maturities[0]);

--- a/test/unit/lending-market-controller/itayose.test.ts
+++ b/test/unit/lending-market-controller/itayose.test.ts
@@ -193,9 +193,11 @@ describe('LendingMarketController - Itayose', () => {
           calculateFutureValue('100000000000000', expectedOpeningPrice),
         );
 
-      const openingPrice = await lendingMarketProxies[0].getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarketProxies[0].getItayoseLog(
+        maturities[0],
+      );
 
-      expect(openingPrice).to.equal(expectedOpeningPrice);
+      expect(openingUnitPrice).to.equal(expectedOpeningPrice);
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency, maturities[0])
@@ -206,7 +208,7 @@ describe('LendingMarketController - Itayose', () => {
 
       expect(
         totalSupplyAfterItayoseExecuted.sub(
-          calculateFutureValue(expectedFilledAmount, openingPrice),
+          calculateFutureValue(expectedFilledAmount, openingUnitPrice),
         ),
       ).lte(1);
 
@@ -220,7 +222,7 @@ describe('LendingMarketController - Itayose', () => {
             next,
             prev,
           }) => {
-            expect(unitPrice).to.lt(openingPrice);
+            expect(unitPrice).to.lt(openingUnitPrice);
             expect(lendingCompoundFactor).to.gt(INITIAL_COMPOUND_FACTOR);
             expect(lendingCompoundFactor).to.equal(borrowingCompoundFactor);
             expect(next).to.equal('0');
@@ -345,9 +347,11 @@ describe('LendingMarketController - Itayose', () => {
           calculateFutureValue('200000000000000', expectedOpeningPrice),
         );
 
-      const openingPrice = await lendingMarketProxies[0].getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarketProxies[0].getItayoseLog(
+        maturities[0],
+      );
 
-      expect(openingPrice).to.equal(expectedOpeningPrice);
+      expect(openingUnitPrice).to.equal(expectedOpeningPrice);
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency, maturities[0])
@@ -358,7 +362,7 @@ describe('LendingMarketController - Itayose', () => {
 
       expect(
         totalSupplyAfterItayoseExecuted.sub(
-          calculateFutureValue(expectedFilledAmount, openingPrice),
+          calculateFutureValue(expectedFilledAmount, openingUnitPrice),
         ),
       ).lte(1);
     });
@@ -426,9 +430,11 @@ describe('LendingMarketController - Itayose', () => {
         ),
       ).to.emit(lendingMarketProxies[0], 'ItayoseExecuted');
 
-      const openingPrice = await lendingMarketProxies[0].getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarketProxies[0].getItayoseLog(
+        maturities[0],
+      );
 
-      expect(openingPrice).to.equal(expectedOpeningPrice);
+      expect(openingUnitPrice).to.equal(expectedOpeningPrice);
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency, maturities[0])
@@ -439,7 +445,7 @@ describe('LendingMarketController - Itayose', () => {
 
       expect(
         totalSupplyAfterItayoseExecuted.sub(
-          calculateFutureValue(expectedFilledAmount, openingPrice),
+          calculateFutureValue(expectedFilledAmount, openingUnitPrice),
         ),
       ).lte(1);
 
@@ -530,9 +536,11 @@ describe('LendingMarketController - Itayose', () => {
         ),
       ).to.emit(lendingMarketProxies[0], 'ItayoseExecuted');
 
-      const openingPrice = await lendingMarketProxies[0].getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarketProxies[0].getItayoseLog(
+        maturities[0],
+      );
 
-      expect(openingPrice).to.equal(expectedOpeningPrice);
+      expect(openingUnitPrice).to.equal(expectedOpeningPrice);
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency, maturities[0])
@@ -543,7 +551,7 @@ describe('LendingMarketController - Itayose', () => {
 
       expect(
         totalSupplyAfterItayoseExecuted.sub(
-          calculateFutureValue(expectedFilledAmount, openingPrice),
+          calculateFutureValue(expectedFilledAmount, openingUnitPrice),
         ),
       ).lte(1);
 
@@ -652,9 +660,11 @@ describe('LendingMarketController - Itayose', () => {
         ),
       ).to.emit(lendingMarket, 'ItayoseExecuted');
 
-      const openingPrice = await lendingMarket.getOpeningUnitPrice();
+      const { openingUnitPrice } = await lendingMarket.getItayoseLog(
+        maturities[maturities.length - 1],
+      );
 
-      expect(openingPrice).to.equal(expectedOpeningPrice);
+      expect(openingUnitPrice).to.equal(expectedOpeningPrice);
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency, maturities[maturities.length - 1])
@@ -667,7 +677,7 @@ describe('LendingMarketController - Itayose', () => {
 
       expect(
         totalSupplyAfterItayoseExecuted.sub(
-          calculateFutureValue(expectedOffsetAmount, openingPrice),
+          calculateFutureValue(expectedOffsetAmount, openingUnitPrice),
         ),
       ).lte(1);
 
@@ -684,10 +694,16 @@ describe('LendingMarketController - Itayose', () => {
       );
 
       expect(aliceFV).to.equal(
-        calculateFutureValue(BigNumber.from('-100000000000000'), openingPrice),
+        calculateFutureValue(
+          BigNumber.from('-100000000000000'),
+          openingUnitPrice,
+        ),
       );
       expect(bobFV).to.equal(
-        calculateFutureValue(BigNumber.from('100000000000000'), openingPrice),
+        calculateFutureValue(
+          BigNumber.from('100000000000000'),
+          openingUnitPrice,
+        ),
       );
       expect(carolFV).to.equal('0');
     });
@@ -747,8 +763,8 @@ describe('LendingMarketController - Itayose', () => {
         ),
       ).to.emit(lendingMarket, 'ItayoseExecuted');
 
-      const openingPrice = await lendingMarket.getOpeningUnitPrice();
-      expect(openingPrice).to.equal('7500');
+      const { openingUnitPrice } = await lendingMarket.getItayoseLog(maturity);
+      expect(openingUnitPrice).to.equal('7500');
 
       const { futureValue: carolFVBefore } =
         await lendingMarketControllerProxy.getPosition(
@@ -836,8 +852,8 @@ describe('LendingMarketController - Itayose', () => {
         ),
       ).to.emit(lendingMarket, 'ItayoseExecuted');
 
-      const openingPrice = await lendingMarket.getOpeningUnitPrice();
-      expect(openingPrice).to.equal('8000');
+      const { openingUnitPrice } = await lendingMarket.getItayoseLog(maturity);
+      expect(openingUnitPrice).to.equal('8000');
 
       const { futureValue: bobFVBefore } =
         await lendingMarketControllerProxy.getPosition(

--- a/test/unit/lending-market.test.ts
+++ b/test/unit/lending-market.test.ts
@@ -354,9 +354,11 @@ describe('LendingMarket', () => {
             }
           });
 
-        const openingPrice = await lendingMarket.getOpeningUnitPrice();
+        const { openingUnitPrice } = await lendingMarket.getItayoseLog(
+          maturity,
+        );
 
-        expect(openingPrice).to.equal(test.openingPrice);
+        expect(openingUnitPrice).to.equal(test.openingPrice);
 
         const itayoseLog = await lendingMarket.getItayoseLog(maturity);
 


### PR DESCRIPTION
- Remove `autoRollFeeRates` from `LendingMarketConfigurationStorage.sol`.
- Merge `openingUnitPrices` to `itayoseLogs` in `LendingMarketStorage.sol`.