### PR TITLE
fix: fix collateral coverage calculation logic [SF-549]

### DIFF
--- a/contracts/mocks/TokenVaultCallerMock.sol
+++ b/contracts/mocks/TokenVaultCallerMock.sol
@@ -57,7 +57,8 @@ contract TokenVaultCallerMock {
     function calculateTotalFundsInBaseCurrency(
         address _user,
         bytes32 _depositCcy,
-        uint256 _depositAmount
+        uint256 _depositAmount,
+        uint256 _liquidationThresholdRate
     )
         public
         view
@@ -76,11 +77,16 @@ contract TokenVaultCallerMock {
             lendingMarketController.calculateTotalFundsInBaseCurrency(
                 _user,
                 _depositCcy,
-                _depositAmount
+                _depositAmount,
+                _liquidationThresholdRate
             );
     }
 
-    function calculateFunds(bytes32 _ccy, address _user)
+    function calculateFunds(
+        bytes32 _ccy,
+        address _user,
+        uint256 _liquidationThresholdRate
+    )
         public
         view
         returns (
@@ -93,7 +99,7 @@ contract TokenVaultCallerMock {
             uint256 borrowedAmount
         )
     {
-        return lendingMarketController.calculateFunds(_ccy, _user);
+        return lendingMarketController.calculateFunds(_ccy, _user, _liquidationThresholdRate);
     }
 
     function cleanUpFunds(bytes32 _ccy, address _user) public returns (uint256 activeOrderCount) {

--- a/contracts/protocol/LendingMarketController.sol
+++ b/contracts/protocol/LendingMarketController.sol
@@ -506,6 +506,7 @@ contract LendingMarketController is
      * for the selected currency.
      * @param _ccy Currency name in bytes32
      * @param _user User's address
+     * @param _liquidationThresholdRate The liquidation threshold rate
      * @return workingLendOrdersAmount The working orders amount on the lend order book
      * @return claimableAmount The claimable amount due to the lending orders being filled on the order book
      * @return collateralAmount The actual collateral amount that is calculated by netting using the haircut.
@@ -514,7 +515,11 @@ contract LendingMarketController is
      * @return debtAmount The debt amount due to the borrow orders being filled on the order book
      * @return borrowedAmount The borrowed amount due to the borrow orders being filled on the order book
      */
-    function calculateFunds(bytes32 _ccy, address _user)
+    function calculateFunds(
+        bytes32 _ccy,
+        address _user,
+        uint256 _liquidationThresholdRate
+    )
         external
         view
         override
@@ -529,7 +534,7 @@ contract LendingMarketController is
         )
     {
         if (Storage.slot().usedCurrencies[_user].contains(_ccy)) {
-            return FundManagementLogic.calculateFunds(_ccy, _user);
+            return FundManagementLogic.calculateFunds(_ccy, _user, _liquidationThresholdRate);
         }
     }
 
@@ -543,7 +548,8 @@ contract LendingMarketController is
     function calculateTotalFundsInBaseCurrency(
         address _user,
         bytes32 _depositCcy,
-        uint256 _depositAmount
+        uint256 _depositAmount,
+        uint256 _liquidationThresholdRate
     )
         external
         view
@@ -563,7 +569,8 @@ contract LendingMarketController is
             FundManagementLogic.calculateTotalFundsInBaseCurrency(
                 _user,
                 _depositCcy,
-                _depositAmount
+                _depositAmount,
+                _liquidationThresholdRate
             );
     }
 

--- a/contracts/protocol/TokenVault.sol
+++ b/contracts/protocol/TokenVault.sol
@@ -97,33 +97,10 @@ contract TokenVault is ITokenVault, MixinAddressResolver, Ownable, Pausable, Pro
     /**
      * @notice Gets if the collateral has enough coverage.
      * @param _user User's address
-     * @param _orderCcy Currency name in bytes32 of an order to be added
-     * @param _orderAmount Amount of an order to be added
-     * @param _orderSide Order position type of an order to be added
-     * @return The boolean if the collateral has sufficient coverage or not
-     */
-    function isCovered(
-        address _user,
-        bytes32 _orderCcy,
-        uint256 _orderAmount,
-        ProtocolTypes.Side _orderSide
-    ) external view override returns (bool) {
-        return
-            DepositManagementLogic.isCovered(
-                _user,
-                _orderCcy,
-                _orderAmount,
-                ProtocolTypes.Side.BORROW == _orderSide
-            );
-    }
-
-    /**
-     * @notice Gets if the collateral has enough coverage.
-     * @param _user User's address
      * @return The boolean if the collateral has sufficient coverage or not
      */
     function isCovered(address _user) public view override returns (bool) {
-        return DepositManagementLogic.isCovered(_user, "", 0, false);
+        return DepositManagementLogic.isCovered(_user);
     }
 
     /**

--- a/contracts/protocol/interfaces/ILendingMarketController.sol
+++ b/contracts/protocol/interfaces/ILendingMarketController.sol
@@ -125,7 +125,11 @@ interface ILendingMarketController {
         view
         returns (Position[] memory positions);
 
-    function calculateFunds(bytes32 ccy, address user)
+    function calculateFunds(
+        bytes32 ccy,
+        address user,
+        uint256 liquidationThresholdRate
+    )
         external
         view
         returns (
@@ -141,7 +145,8 @@ interface ILendingMarketController {
     function calculateTotalFundsInBaseCurrency(
         address user,
         bytes32 depositCcy,
-        uint256 depositAmount
+        uint256 depositAmount,
+        uint256 liquidationThresholdRate
     )
         external
         view

--- a/contracts/protocol/interfaces/ITokenVault.sol
+++ b/contracts/protocol/interfaces/ITokenVault.sol
@@ -10,13 +10,6 @@ interface ITokenVault {
     event CurrencyRegistered(bytes32 ccy, address tokenAddress, bool isCollateral);
     event CurrencyUpdated(bytes32 ccy, bool isCollateral);
 
-    function isCovered(
-        address user,
-        bytes32 orderCcy,
-        uint256 orderAmount,
-        ProtocolTypes.Side orderSide
-    ) external view returns (bool);
-
     function isCovered(address user) external view returns (bool);
 
     function isCollateral(bytes32 ccy) external view returns (bool);

--- a/contracts/protocol/libraries/logics/DepositManagementLogic.sol
+++ b/contracts/protocol/libraries/logics/DepositManagementLogic.sol
@@ -25,17 +25,12 @@ library DepositManagementLogic {
         bool isEnoughDeposit;
     }
 
-    function isCovered(
-        address _user,
-        bytes32 _unsettledOrderCcy,
-        uint256 _unsettledOrderAmount,
-        bool _isUnsettledBorrowOrder
-    ) public view returns (bool) {
+    function isCovered(address _user) public view returns (bool) {
         (uint256 totalCollateral, uint256 totalUsedCollateral, ) = calculateCollateral(
             _user,
-            _unsettledOrderCcy,
-            _unsettledOrderAmount,
-            _isUnsettledBorrowOrder
+            "",
+            0,
+            false
         );
 
         return
@@ -67,7 +62,11 @@ library DepositManagementLogic {
             ,
             ,
             uint256 borrowedAmount
-        ) = AddressResolverLib.lendingMarketController().calculateFunds(_ccy, _user);
+        ) = AddressResolverLib.lendingMarketController().calculateFunds(
+                _ccy,
+                _user,
+                Params.liquidationThresholdRate()
+            );
 
         return
             Storage.slot().depositAmounts[_user][_ccy] +
@@ -105,7 +104,11 @@ library DepositManagementLogic {
             uint256 workingBorrowOrdersAmount,
             uint256 debtAmount,
             uint256 borrowedAmount
-        ) = AddressResolverLib.lendingMarketController().calculateFunds(_ccy, _user);
+        ) = AddressResolverLib.lendingMarketController().calculateFunds(
+                _ccy,
+                _user,
+                Params.liquidationThresholdRate()
+            );
 
         uint256 plusDeposit = Storage.slot().depositAmounts[_user][_ccy] + borrowedAmount;
         uint256 minusDeposit = workingLendOrdersAmount + lentAmount;
@@ -187,7 +190,8 @@ library DepositManagementLogic {
         ) = AddressResolverLib.lendingMarketController().calculateTotalFundsInBaseCurrency(
             _user,
             _unsettledOrderCcy,
-            depositAmount
+            depositAmount,
+            Params.liquidationThresholdRate()
         );
 
         require(

--- a/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
@@ -77,11 +77,6 @@ library LendingMarketUserLogic {
         uint256 activeOrderCount = FundManagementLogic.cleanUpFunds(_ccy, _user);
         FundManagementLogic.registerCurrencyAndMaturity(_ccy, _maturity, _user);
 
-        require(
-            AddressResolverLib.tokenVault().isCovered(_user, _ccy, _amount, _side),
-            "Not enough collateral"
-        );
-
         uint256 circuitBreakerLimitRange = LendingMarketConfigurationLogic
             .getCircuitBreakerLimitRange(_ccy);
 
@@ -123,6 +118,8 @@ library LendingMarketUserLogic {
         );
 
         Storage.slot().usedCurrencies[_user].add(_ccy);
+
+        require(AddressResolverLib.tokenVault().isCovered(_user), "Not enough collateral");
     }
 
     function executePreOrder(
@@ -140,17 +137,16 @@ library LendingMarketUserLogic {
 
         FundManagementLogic.registerCurrencyAndMaturity(_ccy, _maturity, _user);
 
-        require(
-            AddressResolverLib.tokenVault().isCovered(_user, _ccy, _amount, _side),
-            "Not enough collateral"
-        );
-
         ILendingMarket(Storage.slot().maturityLendingMarkets[_ccy][_maturity]).executePreOrder(
             _side,
             _user,
             _amount,
             _unitPrice
         );
+
+        Storage.slot().usedCurrencies[_user].add(_ccy);
+
+        require(AddressResolverLib.tokenVault().isCovered(_user), "Not enough collateral");
     }
 
     function unwindPosition(

--- a/test/common/constants.ts
+++ b/test/common/constants.ts
@@ -8,6 +8,7 @@ export const LIQUIDATOR_FEE_RATE = 500;
 export const INITIAL_COMPOUND_FACTOR = '1000000000000000000';
 export const MARKET_BASE_PERIOD = 3;
 export const MARKET_OBSERVATION_PERIOD = 21600;
+export const HAIRCUT = 8000;
 
 export const wFilToETHRate = BigNumber.from('3803677700000000');
 export const eFilToETHRate = BigNumber.from('3803677700000000');

--- a/test/common/deployment.ts
+++ b/test/common/deployment.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/strings';
 import {
   CIRCUIT_BREAKER_LIMIT_RANGE,
+  HAIRCUT,
   INITIAL_COMPOUND_FACTOR,
   LIQUIDATION_PROTOCOL_FEE_RATE,
   LIQUIDATION_THRESHOLD_RATE,
@@ -240,7 +241,7 @@ const deployContracts = async () => {
     await currencyControllerProxy.addCurrency(
       currency.key,
       decimals,
-      8000, // For testing, set the haircut to 80%
+      HAIRCUT,
       priceFeedAddresses,
     );
   }

--- a/test/integration/deposit.test.ts
+++ b/test/integration/deposit.test.ts
@@ -27,8 +27,6 @@ describe('Integration Test: Deposit', async () => {
   let currencyController: Contract;
   let tokenVault: Contract;
   let lendingMarketController: Contract;
-  let lendingMarketsForWFIL: Contract[] = [];
-  let lendingMarketsForWBTC: Contract[] = [];
   let wETHToken: Contract;
   let usdcToken: Contract;
   let wFILToken: Contract;
@@ -98,26 +96,6 @@ describe('Integration Test: Deposit', async () => {
       await lendingMarketController.createLendingMarket(hexWBTC, genesisDate);
       await lendingMarketController.createLendingMarket(hexUSDC, genesisDate);
     }
-
-    lendingMarketsForWFIL = await lendingMarketController
-      .getLendingMarkets(hexWFIL)
-      .then((addresses) =>
-        Promise.all(
-          addresses.map((address) =>
-            ethers.getContractAt('LendingMarket', address),
-          ),
-        ),
-      );
-
-    lendingMarketsForWBTC = await lendingMarketController
-      .getLendingMarkets(hexWBTC)
-      .then((addresses) =>
-        Promise.all(
-          addresses.map((address) =>
-            ethers.getContractAt('LendingMarket', address),
-          ),
-        ),
-      );
   });
 
   describe('Deposit ETH, Withdraw all collateral', async () => {

--- a/test/unit/lending-market-controller/liquidations.test.ts
+++ b/test/unit/lending-market-controller/liquidations.test.ts
@@ -567,9 +567,6 @@ describe('LendingMarketController - Liquidations', () => {
     it('Fail to liquidate a borrowing position due to insufficient collateral', async () => {
       [alice, bob] = getUsers(2);
 
-      // Set up for the mocks
-      await mockTokenVault.mock['isCovered(address)'].returns(false);
-
       await lendingMarketControllerProxy
         .connect(alice)
         .executeOrder(
@@ -589,6 +586,9 @@ describe('LendingMarketController - Liquidations', () => {
           '100000000',
           '8000',
         );
+
+      // Set up for the mocks
+      await mockTokenVault.mock.isCovered.returns(false);
 
       await expect(
         lendingMarketControllerProxy

--- a/test/unit/lending-market-controller/operations.test.ts
+++ b/test/unit/lending-market-controller/operations.test.ts
@@ -11,6 +11,7 @@ import { getGenesisDate } from '../../../utils/dates';
 import {
   CIRCUIT_BREAKER_LIMIT_RANGE,
   INITIAL_COMPOUND_FACTOR,
+  LIQUIDATION_THRESHOLD_RATE,
   ORDER_FEE_RATE,
 } from '../../common/constants';
 import { deployContracts } from './utils';
@@ -678,11 +679,13 @@ describe('LendingMarketController - Operations', () => {
       const aliceFunds = await lendingMarketControllerProxy.calculateFunds(
         targetCurrency,
         alice.address,
+        LIQUIDATION_THRESHOLD_RATE,
       );
 
       const bobFunds = await lendingMarketControllerProxy.calculateFunds(
         targetCurrency,
         bob.address,
+        LIQUIDATION_THRESHOLD_RATE,
       );
 
       expect(aliceFunds.workingLendOrdersAmount).to.equal('0');
@@ -734,11 +737,13 @@ describe('LendingMarketController - Operations', () => {
       const aliceFunds = await lendingMarketControllerProxy.calculateFunds(
         targetCurrency,
         alice.address,
+        LIQUIDATION_THRESHOLD_RATE,
       );
 
       const bobFunds = await lendingMarketControllerProxy.calculateFunds(
         targetCurrency,
         bob.address,
+        LIQUIDATION_THRESHOLD_RATE,
       );
 
       expect(aliceFunds.workingLendOrdersAmount).to.equal('70000000000000000');

--- a/test/unit/token-vault.test.ts
+++ b/test/unit/token-vault.test.ts
@@ -637,14 +637,6 @@ describe('TokenVault', () => {
       );
 
       expect(await tokenVaultProxy.getCoverage(ellen.address)).to.equal('5000');
-      expect(
-        await tokenVaultProxy['isCovered(address,bytes32,uint256,uint8)'](
-          ellen.address,
-          targetCurrency,
-          '1',
-          1,
-        ),
-      ).to.false;
     });
 
     it('Add and remove the collateral amount', async () => {


### PR DESCRIPTION
- Add the logic to use the lending position (ZC Bonds) as collateral if there are borrowing positions in the same currency.
- Details of the logic are here: https://secured-finance.atlassian.net/browse/SF-549?focusedCommentId=10827