### PR TITLE
fix: fix redemption & repayment bugs [SF-712]

### DIFF
--- a/contracts/protocol/LendingMarketController.sol
+++ b/contracts/protocol/LendingMarketController.sol
@@ -53,7 +53,6 @@ contract LendingMarketController is
      */
     modifier ifValidMaturity(bytes32 _ccy, uint256 _maturity) {
         if (Storage.slot().maturityOrderBookIds[_ccy][_maturity] == 0) revert InvalidMaturity();
-
         _;
     }
 
@@ -939,12 +938,7 @@ contract LendingMarketController is
      * @param _ccy Currency name in bytes32 of the selected market
      */
     function rotateOrderBooks(bytes32 _ccy) external override nonReentrant ifActive {
-        if (!currencyController().currencyExists(_ccy)) revert InvalidCurrency();
-
-        uint256 newMaturity = LendingMarketOperationLogic.rotateOrderBooks(
-            _ccy,
-            getOrderFeeRate(_ccy)
-        );
+        uint256 newMaturity = LendingMarketOperationLogic.rotateOrderBooks(_ccy);
 
         FundManagementLogic.convertFutureValueToGenesisValue(
             _ccy,

--- a/contracts/protocol/libraries/logics/OrderReaderLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderReaderLogic.sol
@@ -13,8 +13,6 @@ library OrderReaderLogic {
     using OrderStatisticsTreeLib for OrderStatisticsTreeLib.Tree;
     using RoundingUint256 for uint256;
 
-    error InvalidMaturity();
-
     function isMatured(uint8 _orderBookId) external view returns (bool) {
         return _getOrderBook(_orderBookId).isMatured();
     }
@@ -217,7 +215,8 @@ library OrderReaderLogic {
         view
         returns (uint256 orderFeeAmount)
     {
-        if (block.timestamp >= _maturity) revert InvalidMaturity();
+        if (block.timestamp >= _maturity) return 0;
+
         uint256 currentMaturity = _maturity - block.timestamp;
 
         // NOTE: The formula is:

--- a/test/integration/liquidations.test.ts
+++ b/test/integration/liquidations.test.ts
@@ -2015,15 +2015,15 @@ describe('Integration Test: Liquidations', async () => {
     let decimals: BigNumber;
     let haircut: BigNumber;
 
+    const addCurrency = async (currency: string) => {
+      if (!(await currencyController.currencyExists(currency))) {
+        await currencyController.addCurrency(currency, decimals, haircut, []);
+      }
+    };
+
     before(async () => {
       decimals = await currencyController.getDecimals(hexWFIL);
       haircut = await currencyController.getHaircut(hexWFIL);
-    });
-
-    afterEach(async () => {
-      if (!(await currencyController.currencyExists(hexWFIL))) {
-        await currencyController.addCurrency(hexWFIL, decimals, haircut, []);
-      }
     });
 
     describe('Repay and redeem positions', async () => {
@@ -2038,6 +2038,10 @@ describe('Integration Test: Liquidations', async () => {
         await resetContractInstances();
 
         lendingInfo = new LendingInfo(alice.address);
+      });
+
+      after(async () => {
+        await addCurrency(hexWFIL);
       });
 
       it('Create orders', async () => {
@@ -2129,6 +2133,10 @@ describe('Integration Test: Liquidations', async () => {
         await resetContractInstances();
 
         lendingInfo = new LendingInfo(alice.address);
+      });
+
+      after(async () => {
+        await addCurrency(hexWFIL);
       });
 
       it('Create orders', async () => {
@@ -2271,6 +2279,10 @@ describe('Integration Test: Liquidations', async () => {
         lendingInfo = new LendingInfo(alice.address);
       });
 
+      after(async () => {
+        await addCurrency(hexWFIL);
+      });
+
       it('Create orders', async () => {
         lendingInfo = new LendingInfo(alice.address);
         aliceInitialBalance = await wFILToken.balanceOf(alice.address);
@@ -2407,6 +2419,10 @@ describe('Integration Test: Liquidations', async () => {
       before(async () => {
         [alice, bob] = await getUsers(2);
         await resetContractInstances();
+      });
+
+      after(async () => {
+        await addCurrency(hexWFIL);
       });
 
       it('Create orders', async () => {
@@ -2555,6 +2571,10 @@ describe('Integration Test: Liquidations', async () => {
         await resetContractInstances();
 
         lendingInfo = new LendingInfo(alice.address);
+      });
+
+      after(async () => {
+        await addCurrency(hexWFIL);
       });
 
       it('Create orders', async () => {

--- a/test/unit/lending-market-controller/rotations.test.ts
+++ b/test/unit/lending-market-controller/rotations.test.ts
@@ -687,5 +687,13 @@ describe('LendingMarketController - Rotations', () => {
       expect(autoRollLog.prev).to.equal(maturities[1]);
       expect(autoRollLog.unitPrice).to.equal('8500');
     });
+
+    it('Fail to rotate order books due to no order book', async () => {
+      await expect(
+        lendingMarketControllerProxy.rotateOrderBooks(
+          ethers.utils.formatBytes32String('Test'),
+        ),
+      ).revertedWith('NotEnoughOrderBooks');
+    });
   });
 });


### PR DESCRIPTION
- Add check logic to the redemption & repayment functions whether the currency is delisted.
- Refactor custom errors in the following functions:
  - rotateOrderBooks
  - initializeLendingMarket
- Add unit tests for testing of custom errors
- Remove an unused function