### PR TITLE
fix: fix a order book rotation bug [SF-141]

### DIFF
--- a/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
@@ -272,6 +272,10 @@ library LendingMarketOperationLogic {
     }
 
     function rotateOrderBooks(bytes32 _ccy) external returns (uint256 newMaturity) {
+        if (!AddressResolverLib.currencyController().currencyExists(_ccy)) {
+            revert InvalidCurrency();
+        }
+
         uint8[] storage orderBookIds = Storage.slot().orderBookIdLists[_ccy];
 
         if (orderBookIds.length < 2) revert NotEnoughOrderBooks();

--- a/test/unit/lending-market-controller/rotations.test.ts
+++ b/test/unit/lending-market-controller/rotations.test.ts
@@ -101,6 +101,10 @@ describe('LendingMarketController - Rotations', () => {
     await initialize(targetCurrency);
   });
 
+  afterEach(async () => {
+    await mockCurrencyController.mock.currencyExists.returns(true);
+  });
+
   describe('Rotations', async () => {
     it('Rotate markets multiple times under condition without lending position', async () => {
       await lendingMarketControllerProxy
@@ -686,6 +690,14 @@ describe('LendingMarketController - Rotations', () => {
 
       expect(autoRollLog.prev).to.equal(maturities[1]);
       expect(autoRollLog.unitPrice).to.equal('8500');
+    });
+
+    it('Fail to rotate order books due to no currency', async () => {
+      await mockCurrencyController.mock.currencyExists.returns(false);
+
+      await expect(
+        lendingMarketControllerProxy.rotateOrderBooks(targetCurrency),
+      ).revertedWith('InvalidCurrency');
     });
 
     it('Fail to rotate order books due to no order book', async () => {


### PR DESCRIPTION
- Add logic to check currency existence to block auto-rolls after the currency is delisted.