### PR TITLE
fix: fix an order estimation bug [SF-724]

### DIFF
--- a/contracts/protocol/libraries/OrderBookLib.sol
+++ b/contracts/protocol/libraries/OrderBookLib.sol
@@ -34,7 +34,7 @@ library OrderBookLib {
     uint256 private constant PRE_ORDER_PERIOD = 7 days;
     uint256 private constant ITAYOSE_PERIOD = 1 hours;
 
-    error NoOrdersExist();
+    error EmptyOrderBook();
     error PastMaturityOrderExists();
 
     struct OrderBook {
@@ -473,6 +473,8 @@ library OrderBookLib {
             isFirstOrderInBlock
         ) = getOrderExecutionConditions(self, _side, _unitPrice, _circuitBreakerLimitRange);
 
+        if (_unitPrice == 0 && !orderExists) revert EmptyOrderBook();
+
         if (isFirstOrderInBlock) {
             self.circuitBreakerThresholdUnitPrices[block.number][_side] = cbThresholdUnitPrice;
         }
@@ -522,8 +524,6 @@ library OrderBookLib {
                 isFirstOrderInBlock = true;
             }
         }
-
-        if (_unitPrice == 0 && !orderExists) revert NoOrdersExist();
 
         if (
             _unitPrice == 0 ||

--- a/test/unit/lending-market-controller/calculations.test.ts
+++ b/test/unit/lending-market-controller/calculations.test.ts
@@ -366,6 +366,36 @@ describe('LendingMarketController - Calculations', () => {
           coverage: '1000',
         },
       },
+      {
+        title: 'Get an borrowing order estimation on the empty order book',
+        orders: [],
+        input: {
+          side: Side.BORROW,
+          amount: '100000000000000000',
+          unitPrice: '0',
+        },
+        result: {
+          lastUnitPrice: '0',
+          filledAmount: '0',
+          filledAmountInFV: '0',
+          coverage: '1000',
+        },
+      },
+      {
+        title: 'Get an lending order estimation on the empty order book',
+        orders: [],
+        input: {
+          side: Side.LEND,
+          amount: '100000000000000000',
+          unitPrice: '0',
+        },
+        result: {
+          lastUnitPrice: '0',
+          filledAmount: '0',
+          filledAmountInFV: '0',
+          coverage: '1000',
+        },
+      },
     ];
 
     for (const condition of conditions) {

--- a/test/unit/lending-market-controller/orders.test.ts
+++ b/test/unit/lending-market-controller/orders.test.ts
@@ -2723,7 +2723,7 @@ describe('LendingMarketController - Orders', () => {
               '10000000000000000',
               '0',
             ),
-        ).to.be.revertedWith('NoOrdersExist');
+        ).to.be.revertedWith('EmptyOrderBook');
       });
 
       it('Fail to place a lend market order', async () => {
@@ -2738,7 +2738,7 @@ describe('LendingMarketController - Orders', () => {
               '0',
               { value: '1000000000000000' },
             ),
-        ).to.be.revertedWith('NoOrdersExist');
+        ).to.be.revertedWith('EmptyOrderBook');
       });
     });
 
@@ -3009,7 +3009,7 @@ describe('LendingMarketController - Orders', () => {
           lendingMarketControllerProxy
             .connect(alice)
             .unwindPosition(targetCurrency, maturities[0]),
-        ).to.be.revertedWith('NoOrdersExist');
+        ).to.be.revertedWith('EmptyOrderBook');
 
         const { futureValue: aliceFV } =
           await lendingMarketControllerProxy.getPosition(


### PR DESCRIPTION
- Fix a bug that the estimation function fail on the empty order book.
- Change the custom error name from `NoOrdersExist` to `EmptyOrderBook` because there is similar name error like `NoOrderExist`.