### PR TITLE
feat: add function to get the last order block number [SF-761]

### DIFF
--- a/contracts/external/LendingMarketReader.sol
+++ b/contracts/external/LendingMarketReader.sol
@@ -18,6 +18,7 @@ contract LendingMarketReader is MixinAddressResolver {
         uint256 bestLendUnitPrice;
         uint256 bestBorrowUnitPrice;
         uint256 marketUnitPrice;
+        uint256 lastOrderBlockNumber;
         uint256[] blockUnitPriceHistory;
         uint256 maxLendUnitPrice;
         uint256 minBorrowUnitPrice;
@@ -204,6 +205,7 @@ contract LendingMarketReader is MixinAddressResolver {
         orderBookDetail.bestLendUnitPrice = market.getBestLendUnitPrice(orderBookId);
         orderBookDetail.bestBorrowUnitPrice = market.getBestBorrowUnitPrice(orderBookId);
         orderBookDetail.marketUnitPrice = market.getMarketUnitPrice(orderBookId);
+        orderBookDetail.lastOrderBlockNumber = market.getLastOrderBlockNumber(orderBookId);
         orderBookDetail.blockUnitPriceHistory = market.getBlockUnitPriceHistory(orderBookId);
         orderBookDetail.openingUnitPrice = market.getItayoseLog(_maturity).openingUnitPrice;
         orderBookDetail.isReady = market.isReady(orderBookId);

--- a/contracts/protocol/LendingMarket.sol
+++ b/contracts/protocol/LendingMarket.sol
@@ -257,6 +257,15 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
     }
 
     /**
+     * @notice Gets the block number of the last filled order.
+     * @param _orderBookId The order book id
+     * @return The block number
+     */
+    function getLastOrderBlockNumber(uint8 _orderBookId) external view override returns (uint256) {
+        return OrderBookLogic.getLastOrderBlockNumber(_orderBookId);
+    }
+
+    /**
      * @notice Gets the block unit price history
      * @param _orderBookId The order book id
      * @return The array of the block unit price

--- a/contracts/protocol/interfaces/ILendingMarket.sol
+++ b/contracts/protocol/interfaces/ILendingMarket.sol
@@ -43,6 +43,8 @@ interface ILendingMarket {
 
     function getMarketUnitPrice(uint8 orderBookId) external view returns (uint256);
 
+    function getLastOrderBlockNumber(uint8 _orderBookId) external view returns (uint256);
+
     function getBlockUnitPriceHistory(uint8 _orderBookId) external view returns (uint256[] memory);
 
     function getBlockUnitPriceAverage(uint8 orderBookId, uint256 count)

--- a/contracts/protocol/libraries/logics/OrderActionLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderActionLogic.sol
@@ -216,7 +216,8 @@ library OrderActionLogic {
         ) = orderBook.getOrderExecutionConditions(
             _side,
             _unitPrice,
-            Storage.slot().circuitBreakerLimitRange
+            Storage.slot().circuitBreakerLimitRange,
+            false
         );
 
         if (_unitPrice == 0 && !vars.conditions.orderExists) revert EmptyOrderBook();
@@ -338,7 +339,8 @@ library OrderActionLogic {
         ) = orderBook.getOrderExecutionConditions(
             _side,
             0,
-            Storage.slot().circuitBreakerLimitRange
+            Storage.slot().circuitBreakerLimitRange,
+            false
         );
 
         if (!conditions.orderExists) revert EmptyOrderBook();

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -76,12 +76,16 @@ library OrderBookLogic {
         preOpeningDate = orderBook.preOpeningDate;
     }
 
+    function getLastOrderBlockNumber(uint8 _orderBookId) external view returns (uint256) {
+        return _getOrderBook(_orderBookId).lastOrderBlockNumber;
+    }
+
     function getBlockUnitPriceHistory(uint8 _orderBookId) external view returns (uint256[] memory) {
-        return _getOrderBook(_orderBookId).getBlockUnitPriceHistory();
+        return _getOrderBook(_orderBookId).getBlockUnitPriceHistory(true);
     }
 
     function getMarketUnitPrice(uint8 _orderBookId) external view returns (uint256) {
-        return _getOrderBook(_orderBookId).getMarketUnitPrice();
+        return _getOrderBook(_orderBookId).getMarketUnitPrice(true);
     }
 
     function getBlockUnitPriceAverage(uint8 _orderBookId, uint256 _count)
@@ -89,7 +93,7 @@ library OrderBookLogic {
         view
         returns (uint256)
     {
-        return _getOrderBook(_orderBookId).getBlockUnitPriceAverage(_count);
+        return _getOrderBook(_orderBookId).getBlockUnitPriceAverage(_count, true);
     }
 
     function getCircuitBreakerThresholds(uint8 _orderBookId)
@@ -98,10 +102,12 @@ library OrderBookLogic {
         returns (uint256 maxLendUnitPrice, uint256 minBorrowUnitPrice)
     {
         maxLendUnitPrice = _getOrderBook(_orderBookId).getLendCircuitBreakerThreshold(
-            Storage.slot().circuitBreakerLimitRange
+            Storage.slot().circuitBreakerLimitRange,
+            true
         );
         minBorrowUnitPrice = _getOrderBook(_orderBookId).getBorrowCircuitBreakerThreshold(
-            Storage.slot().circuitBreakerLimitRange
+            Storage.slot().circuitBreakerLimitRange,
+            true
         );
     }
 
@@ -237,7 +243,7 @@ library OrderBookLogic {
 
         // NOTE: The auto-roll destination order book has no market unit price if the order has never been filled before.
         // In this case, the market unit price is updated with the unit price of the auto-roll.
-        if (destinationOrderBook.getMarketUnitPrice() == 0) {
+        if (destinationOrderBook.getMarketUnitPrice(false) == 0) {
             destinationOrderBook.setInitialBlockUnitPrice(_autoRollUnitPrice);
         }
     }

--- a/contracts/protocol/libraries/logics/OrderReaderLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderReaderLogic.sol
@@ -188,7 +188,8 @@ library OrderReaderLogic {
             .getOrderExecutionConditions(
                 _side,
                 _unitPrice,
-                Storage.slot().circuitBreakerLimitRange
+                Storage.slot().circuitBreakerLimitRange,
+                true
             );
 
         if (isFilled) {

--- a/test/unit/lending-market-controller/operations.test.ts
+++ b/test/unit/lending-market-controller/operations.test.ts
@@ -174,6 +174,7 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.bestLendUnitPrice).to.equal('10000');
       expect(detail.bestBorrowUnitPrice).to.equal('0');
       expect(detail.marketUnitPrice).to.equal('0');
+      expect(detail.lastOrderBlockNumber).to.equal('0');
       expect(detail.blockUnitPriceHistory[0]).to.equal('0');
       expect(detail.maxLendUnitPrice).to.equal('10000');
       expect(detail.minBorrowUnitPrice).to.equal('1');
@@ -212,7 +213,7 @@ describe('LendingMarketController - Operations', () => {
           '8000',
         );
 
-      await lendingMarketControllerProxy
+      const tx = await lendingMarketControllerProxy
         .connect(bob)
         .executeOrder(
           targetCurrency,
@@ -232,6 +233,7 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.bestLendUnitPrice).to.equal('9000');
       expect(detail.bestBorrowUnitPrice).to.equal('5000');
       expect(detail.marketUnitPrice).to.equal('8000');
+      expect(detail.lastOrderBlockNumber).to.equal(tx.blockNumber);
       expect(detail.blockUnitPriceHistory[0]).to.equal('8000');
       expect(detail.maxLendUnitPrice).to.equal('8800');
       expect(detail.minBorrowUnitPrice).to.equal('7600');

--- a/test/unit/lending-market-controller/orders.test.ts
+++ b/test/unit/lending-market-controller/orders.test.ts
@@ -1198,7 +1198,7 @@ describe('LendingMarketController - Orders', () => {
       expect(positions[0].ccy).to.equal(targetCurrency);
       expect(positions[0].maturity).to.equal(maturities[0]);
       expect(positions[0].futureValue).to.equal('8333333333333333');
-      expect(positions[0].presentValue).to.equal('6250000000000000');
+      expect(positions[0].presentValue).to.equal('6666666666666666');
     });
 
     it('Get active positions from multiple markets', async () => {


### PR DESCRIPTION
- Add a function to get the last order block number
- Fix a bug that the functions to get the block unit price & market unit price return old data when it is an external call at the same block as the last order block number.