### PR TITLE
feat: add a function to estimate Itayose results [SF-783]

### DIFF
--- a/contracts/protocol/LendingMarket.sol
+++ b/contracts/protocol/LendingMarket.sol
@@ -333,6 +333,27 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
     }
 
     /**
+     * @notice Gets the estimation of the Itayose process.
+     * @param _orderBookId The order book id
+     * @return openingUnitPrice The opening price when Itayose is executed
+     * @return lastLendUnitPrice The price of the last lend order filled by Itayose.
+     * @return lastBorrowUnitPrice The price of the last borrow order filled by Itayose.
+     * @return totalOffsetAmount The total amount of the orders filled by Itayose.
+     */
+    function getItayoseEstimation(uint8 _orderBookId)
+        external
+        view
+        returns (
+            uint256 openingUnitPrice,
+            uint256 lastLendUnitPrice,
+            uint256 lastBorrowUnitPrice,
+            uint256 totalOffsetAmount
+        )
+    {
+        return OrderBookLogic.getItayoseEstimation(_orderBookId);
+    }
+
+    /**
      * @notice Gets the current market maturity.
      * @param _orderBookId The order book id
      * @return maturity The market maturity

--- a/contracts/protocol/TokenVault.sol
+++ b/contracts/protocol/TokenVault.sol
@@ -214,7 +214,7 @@ contract TokenVault is
     /**
      * @notice Gets the total collateral amount.
      * @param _user User's address
-     * @return totalCollateralAmount The total collateral amount in ETH
+     * @return totalCollateralAmount The total collateral amount in the base currency
      */
     function getTotalCollateralAmount(address _user)
         external

--- a/contracts/protocol/interfaces/ILendingMarket.sol
+++ b/contracts/protocol/interfaces/ILendingMarket.sol
@@ -43,9 +43,9 @@ interface ILendingMarket {
 
     function getMarketUnitPrice(uint8 orderBookId) external view returns (uint256);
 
-    function getLastOrderBlockNumber(uint8 _orderBookId) external view returns (uint256);
+    function getLastOrderBlockNumber(uint8 orderBookId) external view returns (uint256);
 
-    function getBlockUnitPriceHistory(uint8 _orderBookId) external view returns (uint256[] memory);
+    function getBlockUnitPriceHistory(uint8 orderBookId) external view returns (uint256[] memory);
 
     function getBlockUnitPriceAverage(uint8 orderBookId, uint256 count)
         external
@@ -68,6 +68,16 @@ interface ILendingMarket {
             uint256[] memory unitPrices,
             uint256[] memory amounts,
             uint256[] memory quantities
+        );
+
+    function getItayoseEstimation(uint8 orderBookId)
+        external
+        view
+        returns (
+            uint256 openingUnitPrice,
+            uint256 lastLendUnitPrice,
+            uint256 lastBorrowUnitPrice,
+            uint256 totalOffsetAmount
         );
 
     function getMaturity(uint8 orderBookId) external view returns (uint256);
@@ -233,9 +243,9 @@ interface ILendingMarket {
             uint256 maturity
         );
 
-    function updateOrderFeeRate(uint256 _orderFeeRate) external;
+    function updateOrderFeeRate(uint256 orderFeeRate) external;
 
-    function updateCircuitBreakerLimitRange(uint256 _limitRange) external;
+    function updateCircuitBreakerLimitRange(uint256 limitRange) external;
 
     function pauseMarket() external;
 

--- a/contracts/protocol/libraries/OrderBookLib.sol
+++ b/contracts/protocol/libraries/OrderBookLib.sol
@@ -523,7 +523,7 @@ library OrderBookLib {
         return (side, removedAmount, unitPrice);
     }
 
-    function getOpeningUnitPrice(OrderBook storage self)
+    function calculateItayoseResult(OrderBook storage self)
         internal
         view
         returns (
@@ -533,18 +533,18 @@ library OrderBookLib {
             uint256 totalOffsetAmount
         )
     {
-        uint256 lendUnitPrice = getBestBorrowUnitPrice(self);
-        uint256 borrowUnitPrice = getBestLendUnitPrice(self);
+        uint256 lendUnitPrice = self.lendOrders[self.maturity].last();
+        uint256 borrowUnitPrice = self.borrowOrders[self.maturity].first();
         uint256 lendAmount = self.lendOrders[self.maturity].getNodeTotalAmount(lendUnitPrice);
         uint256 borrowAmount = self.borrowOrders[self.maturity].getNodeTotalAmount(borrowUnitPrice);
 
         OrderStatisticsTreeLib.Tree storage borrowOrders = self.borrowOrders[self.maturity];
         OrderStatisticsTreeLib.Tree storage lendOrders = self.lendOrders[self.maturity];
 
-        // return mid price when no lending and borrowing orders overwrap
-        if (borrowUnitPrice > lendUnitPrice) {
+        // Return 0 if no orders is filled
+        if (borrowUnitPrice > lendUnitPrice || borrowUnitPrice == 0 || lendUnitPrice == 0) {
             openingUnitPrice = (lendUnitPrice + borrowUnitPrice).div(2);
-            return (openingUnitPrice, 0, 0, 0);
+            return (0, 0, 0, 0);
         }
 
         while (borrowUnitPrice <= lendUnitPrice && borrowUnitPrice > 0 && lendUnitPrice > 0) {

--- a/contracts/protocol/libraries/logics/DepositManagementLogic.sol
+++ b/contracts/protocol/libraries/logics/DepositManagementLogic.sol
@@ -413,7 +413,7 @@ library DepositManagementLogic {
      * @notice Gets the total of amount deposited in the user's collateral of all currencies
      *  in this contract by converting it to ETH.
      * @param _user Address of collateral user
-     * @return totalDepositAmount The total deposited amount in ETH
+     * @return totalDepositAmount The total deposited amount in the base currency
      */
     function _getTotalInternalDepositAmountInBaseCurrency(address _user)
         internal

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -167,6 +167,19 @@ library OrderBookLogic {
         return _getOrderBook(_orderBookId).getLendOrderBook(_limit);
     }
 
+    function getItayoseEstimation(uint8 _orderBookId)
+        external
+        view
+        returns (
+            uint256 openingUnitPrice,
+            uint256 lastLendUnitPrice,
+            uint256 lastBorrowUnitPrice,
+            uint256 totalOffsetAmount
+        )
+    {
+        return _getOrderBook(_orderBookId).calculateItayoseResult();
+    }
+
     function getMaturities(uint8[] memory _orderBookIds)
         public
         view
@@ -263,7 +276,7 @@ library OrderBookLogic {
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
 
         (openingUnitPrice, lastLendUnitPrice, lastBorrowUnitPrice, totalOffsetAmount) = orderBook
-            .getOpeningUnitPrice();
+            .calculateItayoseResult();
 
         if (totalOffsetAmount > 0) {
             ProtocolTypes.Side[2] memory sides = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19056,6 +19056,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -19368,6 +19369,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/test/integration/itayose.test.ts
+++ b/test/integration/itayose.test.ts
@@ -205,6 +205,20 @@ describe('Integration Test: Itayose', async () => {
       ).to.emit(lendingMarketOperationLogic, 'OrderBooksRotated');
     });
 
+    it('Check the expected result before Itayose execution', async () => {
+      const marketInfo = await lendingMarketReader.getOrderBookDetail(
+        hexETH,
+        maturities[maturities.length - 1],
+      );
+
+      expect(marketInfo.openingDate).to.equal(maturities[0]);
+      expect(marketInfo.bestLendUnitPrice).to.equal('10000');
+      expect(marketInfo.bestBorrowUnitPrice).to.equal('0');
+      expect(marketInfo.marketUnitPrice).to.equal('0');
+      expect(marketInfo.blockUnitPriceHistory[0]).to.equal('0');
+      expect(marketInfo.openingUnitPrice).to.equal('0');
+    });
+
     it('Execute Itayose without pre-order', async () => {
       const orderBookId = orderBookIds[orderBookIds.length - 1];
       const maturity = maturities[maturities.length - 1];
@@ -224,7 +238,7 @@ describe('Integration Test: Itayose', async () => {
       expect(marketInfo.bestBorrowUnitPrice).to.equal('0');
       expect(marketInfo.marketUnitPrice).to.equal('0');
       expect(marketInfo.blockUnitPriceHistory[0]).to.equal('0');
-      expect(marketInfo.openingUnitPrice).to.equal('5000');
+      expect(marketInfo.openingUnitPrice).to.equal('0');
     });
   });
 
@@ -328,6 +342,21 @@ describe('Integration Test: Itayose', async () => {
       await expect(
         lendingMarketController.connect(owner).rotateOrderBooks(hexETH),
       ).to.emit(lendingMarketOperationLogic, 'OrderBooksRotated');
+    });
+
+    it('Check the expected result before Itayose execution', async () => {
+      const marketInfo = await lendingMarketReader.getOrderBookDetail(
+        hexETH,
+        maturities[maturities.length - 1],
+      );
+
+      expect(marketInfo.openingDate).to.equal(maturities[0]);
+      expect(marketInfo.bestLendUnitPrice).to.equal('7300');
+      expect(marketInfo.bestBorrowUnitPrice).to.equal('7400');
+      expect(marketInfo.marketUnitPrice).to.equal('0');
+      expect(marketInfo.blockUnitPriceHistory[0]).to.equal('0');
+      expect(marketInfo.blockUnitPriceHistory[1]).to.equal('0');
+      expect(marketInfo.openingUnitPrice).to.equal('7300');
     });
 
     it('Execute Itayose with pre-order', async () => {

--- a/test/unit/currency-contoroller.test.ts
+++ b/test/unit/currency-contoroller.test.ts
@@ -304,7 +304,7 @@ describe('CurrencyController', () => {
       );
     });
 
-    it('Get the converted amount(int256) in ETH', async () => {
+    it('Get the converted amount(int256) in the base currency', async () => {
       const amount = await currencyControllerProxy[
         'convertToBaseCurrency(bytes32,int256)'
       ](currency, 10000000000);
@@ -312,7 +312,7 @@ describe('CurrencyController', () => {
       expect(amount).to.equal('100');
     });
 
-    it('Get the converted amount(uint256) in ETH', async () => {
+    it('Get the converted amount(uint256) in the base currency', async () => {
       const amount = await currencyControllerProxy[
         'convertToBaseCurrency(bytes32,uint256)'
       ](currency, 10000000000);
@@ -320,7 +320,7 @@ describe('CurrencyController', () => {
       expect(amount).to.equal('100');
     });
 
-    it('Get the array of converted amounts(uint256[]) in ETH', async () => {
+    it('Get the array of converted amounts(uint256[]) in the base currency', async () => {
       const amounts = await currencyControllerProxy[
         'convertToBaseCurrency(bytes32,uint256[])'
       ](currency, [10000000000]);

--- a/test/unit/lending-market-controller/itayose.test.ts
+++ b/test/unit/lending-market-controller/itayose.test.ts
@@ -103,6 +103,24 @@ describe('LendingMarketController - Itayose', () => {
       orderBookLogic = orderBookLogic.attach(lendingMarketProxy.address);
     };
 
+    it('Get Itayose estimation with no pre-orders', async () => {
+      const { timestamp } = await ethers.provider.getBlock('latest');
+      const openingDate = moment(timestamp * 1000)
+        .add(2, 'h')
+        .unix();
+
+      await initialize(targetCurrency, openingDate);
+
+      const estimation = await lendingMarketReader.getItayoseEstimation(
+        targetCurrency,
+        maturities[0],
+      );
+
+      expect(estimation.openingUnitPrice).to.equal('0');
+      expect(estimation.lastLendUnitPrice).to.equal('0');
+      expect(estimation.lastBorrowUnitPrice).to.equal('0');
+    });
+
     it('Execute Itayose call on the initial markets, the opening price become the same as the lending order', async () => {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const openingDate = moment(timestamp * 1000)
@@ -182,6 +200,11 @@ describe('LendingMarketController - Itayose', () => {
 
       await time.increaseTo(openingDate);
 
+      const estimation = await lendingMarketReader.getItayoseEstimation(
+        targetCurrency,
+        maturities[0],
+      );
+
       // Execute Itayose call on the first market
       const tx = await lendingMarketControllerProxy.executeItayoseCalls(
         [targetCurrency],
@@ -205,6 +228,9 @@ describe('LendingMarketController - Itayose', () => {
       );
 
       expect(openingUnitPrice).to.equal(expectedOpeningPrice);
+      expect(estimation.openingUnitPrice).to.equal(expectedOpeningPrice);
+      expect(estimation.lastLendUnitPrice).to.equal('8300');
+      expect(estimation.lastBorrowUnitPrice).to.equal('8000');
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency)
@@ -343,6 +369,11 @@ describe('LendingMarketController - Itayose', () => {
 
       await time.increaseTo(openingDate);
 
+      const estimation = await lendingMarketReader.getItayoseEstimation(
+        targetCurrency,
+        maturities[0],
+      );
+
       // Execute Itayose call on the first market
       const tx = await lendingMarketControllerProxy.executeItayoseCalls(
         [targetCurrency],
@@ -366,6 +397,9 @@ describe('LendingMarketController - Itayose', () => {
       );
 
       expect(openingUnitPrice).to.equal(expectedOpeningPrice);
+      expect(estimation.openingUnitPrice).to.equal(expectedOpeningPrice);
+      expect(estimation.lastLendUnitPrice).to.equal('8600');
+      expect(estimation.lastBorrowUnitPrice).to.equal('8500');
 
       const futureValueVaultProxy: Contract = await lendingMarketControllerProxy
         .getFutureValueVault(targetCurrency)

--- a/test/unit/lending-market/itayose.test.ts
+++ b/test/unit/lending-market/itayose.test.ts
@@ -120,10 +120,8 @@ describe('LendingMarket - Itayose', () => {
       lastBorrowUnitPrice: 8100,
     },
     {
-      openingPrice: '4000', // 0 + 8,000 = 4,000 / 2
+      openingPrice: '0',
       orders: [
-        { side: Side.BORROW, unitPrice: '8500', amount: '300000000000000' },
-        { side: Side.BORROW, unitPrice: '8100', amount: '100000000000000' },
         { side: Side.BORROW, unitPrice: '8000', amount: '50000000000000' },
       ],
       shouldItayoseExecuted: false,
@@ -131,18 +129,16 @@ describe('LendingMarket - Itayose', () => {
       lastBorrowUnitPrice: 0,
     },
     {
-      openingPrice: '9150', // 10,000 + 8,300 = 9,150 / 2
+      openingPrice: '0',
       orders: [
         { side: Side.LEND, unitPrice: '8300', amount: '100000000000000' },
-        { side: Side.LEND, unitPrice: '8200', amount: '200000000000000' },
-        { side: Side.LEND, unitPrice: '7800', amount: '300000000000000' },
       ],
       shouldItayoseExecuted: false,
       lastLendUnitPrice: 0,
       lastBorrowUnitPrice: 0,
     },
     {
-      openingPrice: '8150', // 7,800 + 8,500 / 2
+      openingPrice: '0',
       orders: [
         { side: Side.BORROW, unitPrice: '8500', amount: '300000000000000' },
         { side: Side.LEND, unitPrice: '7800', amount: '300000000000000' },


### PR DESCRIPTION
- Add a function to get Itayose estimation
- Update the `getOrderBookDetail` function to use Itayose estimation for opening price
- Update the Itayose logic to use 0 as opening price when no orders are filled
- Update wrong comments