### PR TITLE
feat: add a new function to get last price [SF-800]

### DIFF
--- a/contracts/protocol/interfaces/ICurrencyController.sol
+++ b/contracts/protocol/interfaces/ICurrencyController.sol
@@ -77,7 +77,9 @@ interface ICurrencyController {
 
     function getPriceFeed(bytes32 _ccy) external view returns (PriceFeed memory);
 
-    function getLastPrice(bytes32 _ccy) external view returns (int256);
+    function getLastPrice(bytes32 _ccy) external view returns (int256 price);
+
+    function getAggregatedLastPrice(bytes32 _ccy) external view returns (int256);
 
     function currencyExists(bytes32 _ccy) external view returns (bool);
 

--- a/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
@@ -264,7 +264,7 @@ library LendingMarketOperationLogic {
             pauseLendingMarkets(ccy);
             Storage.slot().marketTerminationPrices[ccy] = AddressResolverLib
                 .currencyController()
-                .getLastPrice(ccy);
+                .getAggregatedLastPrice(ccy);
         }
 
         for (uint256 i; i < collateralCurrencies.length; i++) {

--- a/test/unit/currency-contoroller.test.ts
+++ b/test/unit/currency-contoroller.test.ts
@@ -196,6 +196,9 @@ describe('CurrencyController', () => {
         ),
       ).to.emit(currencyControllerProxy, 'PriceFeedUpdated');
 
+      expect(
+        await currencyControllerProxy.getAggregatedLastPrice(currency),
+      ).to.equal(200);
       expect(await currencyControllerProxy.getLastPrice(currency)).to.equal(
         200,
       );
@@ -213,10 +216,22 @@ describe('CurrencyController', () => {
         owner,
         MockV3Aggregator.abi,
       );
-      await newMockPriceFeed1.mock.latestRoundData.returns(0, 200, 0, now, 0);
+      await newMockPriceFeed1.mock.latestRoundData.returns(
+        0,
+        '2000000',
+        0,
+        now,
+        0,
+      );
       await newMockPriceFeed1.mock.getRoundData.returns(0, 200, 0, 2000, 0);
       await newMockPriceFeed1.mock.decimals.returns(6);
-      await newMockPriceFeed2.mock.latestRoundData.returns(0, 400, 0, now, 0);
+      await newMockPriceFeed2.mock.latestRoundData.returns(
+        0,
+        '4000000000000000000',
+        0,
+        now,
+        0,
+      );
       await newMockPriceFeed2.mock.getRoundData.returns(0, 500, 0, 1000, 0);
       await newMockPriceFeed2.mock.decimals.returns(18);
 
@@ -230,8 +245,11 @@ describe('CurrencyController', () => {
       ).to.emit(currencyControllerProxy, 'PriceFeedUpdated');
 
       expect(await currencyControllerProxy.getDecimals(currency)).to.equal(18);
+      expect(
+        await currencyControllerProxy.getAggregatedLastPrice(currency),
+      ).to.equal('8000000000000000000000000');
       expect(await currencyControllerProxy.getLastPrice(currency)).to.equal(
-        80000,
+        '8000000000000000000',
       );
     });
 

--- a/test/unit/lending-market-controller/terminations.test.ts
+++ b/test/unit/lending-market-controller/terminations.test.ts
@@ -93,7 +93,7 @@ describe('LendingMarketController - Terminations', () => {
     await mockCurrencyController.mock.getDecimals.returns(18);
     await mockCurrencyController.mock.currencyExists.returns(true);
     await mockCurrencyController.mock.getCurrencies.returns([targetCurrency]);
-    await mockCurrencyController.mock.getLastPrice.returns(
+    await mockCurrencyController.mock.getAggregatedLastPrice.returns(
       '1000000000000000000',
     );
     await mockCurrencyController.mock[


### PR DESCRIPTION
- Rename the previous `getLastPrice` function to `getAggregatedLastPrice`.
- Add a new `getLastPrice` function to get the last price in USD.