### PR TITLE
feat: add cleanup logic to unwinding [SF-811]

### DIFF
--- a/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
@@ -166,6 +166,8 @@ library LendingMarketUserLogic {
         uint256 _maturity,
         address _user
     ) external {
+        FundManagementLogic.cleanUpFunds(_ccy, _user);
+
         int256 futureValue = FundManagementLogic
             .getActualFunds(_ccy, _maturity, _user, 0)
             .futureValue;


### PR DESCRIPTION
In terms of consistency, the cleanup function should be executed before the order is executed even if it is the unwinding function.
(This PR is not the cause of SF-811 really)