### PR TITLE
feat: add a function to get revision [SF-143]

### DIFF
--- a/contracts/protocol/utils/Proxyable.sol
+++ b/contracts/protocol/utils/Proxyable.sol
@@ -20,6 +20,10 @@ abstract contract Proxyable is Initializable {
         _;
     }
 
+    function getRevision() external pure virtual returns (uint256) {
+        return 0x1;
+    }
+
     function _getImplementation() private view returns (address) {
         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
     }

--- a/test/unit/proxy-controller.test.ts
+++ b/test/unit/proxy-controller.test.ts
@@ -209,6 +209,9 @@ describe('ProxyController', () => {
       const haircut1 = await currencyControllerProxy1.getHaircut(hexWBTC);
       expect(haircut1.toString()).to.equal(HAIRCUT.toString());
 
+      const revision = await currencyControllerProxy1.getRevision();
+      expect(revision.toString()).to.equal('1');
+
       // update (second time)
       const currencyController2 = await deployContract(
         owner,


### PR DESCRIPTION
- Add the `getRevision` function in the `Proxyable` contract. 

When we update smart contracts, we need to override the `getRevision` function to return a new revision.