### PR TITLE
feat: update getOrderBookDetail [SF-760]

### DIFF
--- a/contracts/external/LendingMarketReader.sol
+++ b/contracts/external/LendingMarketReader.sol
@@ -25,6 +25,7 @@ contract LendingMarketReader is MixinAddressResolver {
         uint256 openingUnitPrice;
         uint256 openingDate;
         uint256 preOpeningDate;
+        uint256 currentMinDebtUnitPrice;
         bool isReady;
     }
 
@@ -238,6 +239,9 @@ contract LendingMarketReader is MixinAddressResolver {
         } else {
             (orderBookDetail.openingUnitPrice, , , ) = market.getItayoseEstimation(orderBookId);
         }
+
+        orderBookDetail.currentMinDebtUnitPrice = lendingMarketController()
+            .getCurrentMinDebtUnitPrice(_ccy, _maturity);
     }
 
     /**

--- a/test/unit/lending-market-controller/operations.test.ts
+++ b/test/unit/lending-market-controller/operations.test.ts
@@ -180,6 +180,19 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.minBorrowUnitPrice).to.equal('1');
       expect(detail.openingUnitPrice).to.equal('0');
       expect(detail.isReady).to.equal(true);
+
+      const minDebtUnitPrice =
+        await lendingMarketControllerProxy.getMinDebtUnitPrice(targetCurrency);
+      const { timestamp } = await ethers.provider.getBlock('latest');
+
+      expect(detail.currentMinDebtUnitPrice).to.equal(
+        BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE).sub(
+          BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE)
+            .sub(minDebtUnitPrice)
+            .mul(maturities[0].sub(timestamp))
+            .div(SECONDS_IN_YEAR),
+        ),
+      );
     });
 
     it('Get the lending market detail with non-empty order book', async () => {
@@ -239,6 +252,19 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.minBorrowUnitPrice).to.equal('7600');
       expect(detail.openingUnitPrice).to.equal('0');
       expect(detail.isReady).to.equal(true);
+
+      const minDebtUnitPrice =
+        await lendingMarketControllerProxy.getMinDebtUnitPrice(targetCurrency);
+      const { timestamp } = await ethers.provider.getBlock('latest');
+
+      expect(detail.currentMinDebtUnitPrice).to.equal(
+        BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE).sub(
+          BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE)
+            .sub(minDebtUnitPrice)
+            .mul(maturities[0].sub(timestamp))
+            .div(SECONDS_IN_YEAR),
+        ),
+      );
     });
 
     it('Get the multiple lending market details', async () => {


### PR DESCRIPTION
- Add `currentMinDebtUnitPrice` in the response of `getOrderBookDetail()`.