### PR TITLE
fix: fix an auto-roll price discovery mechanism bug [SF-902]

### DIFF
--- a/contracts/external/LendingMarketReader.sol
+++ b/contracts/external/LendingMarketReader.sol
@@ -18,8 +18,8 @@ contract LendingMarketReader is MixinAddressResolver {
         uint256 bestLendUnitPrice;
         uint256 bestBorrowUnitPrice;
         uint256 marketUnitPrice;
-        uint256 lastOrderBlockNumber;
         uint256[] blockUnitPriceHistory;
+        uint256 lastBlockUnitPriceTimestamp;
         uint256 maxLendUnitPrice;
         uint256 minBorrowUnitPrice;
         uint256 openingUnitPrice;
@@ -225,9 +225,12 @@ contract LendingMarketReader is MixinAddressResolver {
         orderBookDetail.bestLendUnitPrice = market.getBestLendUnitPrice(orderBookId);
         orderBookDetail.bestBorrowUnitPrice = market.getBestBorrowUnitPrice(orderBookId);
         orderBookDetail.marketUnitPrice = market.getMarketUnitPrice(orderBookId);
-        orderBookDetail.lastOrderBlockNumber = market.getLastOrderBlockNumber(orderBookId);
-        orderBookDetail.blockUnitPriceHistory = market.getBlockUnitPriceHistory(orderBookId);
         orderBookDetail.isReady = market.isReady(orderBookId);
+
+        (
+            orderBookDetail.blockUnitPriceHistory,
+            orderBookDetail.lastBlockUnitPriceTimestamp
+        ) = market.getBlockUnitPriceHistory(orderBookId);
 
         (, , orderBookDetail.openingDate, orderBookDetail.preOpeningDate) = market
             .getOrderBookDetail(orderBookId);

--- a/contracts/protocol/LendingMarket.sol
+++ b/contracts/protocol/LendingMarket.sol
@@ -245,22 +245,23 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
     }
 
     /**
-     * @notice Gets the block number of the last filled order.
+     * @notice Gets the block timestamp of the last filled order.
      * @param _orderBookId The order book id
      * @return The block number
      */
-    function getLastOrderBlockNumber(uint8 _orderBookId) external view override returns (uint256) {
-        return OrderBookLogic.getLastOrderBlockNumber(_orderBookId);
+    function getLastOrderTimestamp(uint8 _orderBookId) external view override returns (uint48) {
+        return OrderBookLogic.getLastOrderTimestamp(_orderBookId);
     }
 
     /**
      * @notice Gets the block unit price history
      * @param _orderBookId The order book id
-     * @return The array of the block unit price
+     * @return unitPrices The array of the block unit price
+     * @return timestamp Timestamp of the last block unit price
      */
     function getBlockUnitPriceHistory(
         uint8 _orderBookId
-    ) external view override returns (uint256[] memory) {
+    ) external view override returns (uint256[] memory unitPrices, uint48 timestamp) {
         return OrderBookLogic.getBlockUnitPriceHistory(_orderBookId);
     }
 

--- a/contracts/protocol/interfaces/ILendingMarket.sol
+++ b/contracts/protocol/interfaces/ILendingMarket.sol
@@ -40,9 +40,11 @@ interface ILendingMarket {
 
     function getMarketUnitPrice(uint8 orderBookId) external view returns (uint256);
 
-    function getLastOrderBlockNumber(uint8 orderBookId) external view returns (uint256);
+    function getLastOrderTimestamp(uint8 orderBookId) external view returns (uint48);
 
-    function getBlockUnitPriceHistory(uint8 orderBookId) external view returns (uint256[] memory);
+    function getBlockUnitPriceHistory(
+        uint8 orderBookId
+    ) external view returns (uint256[] memory unitPrices, uint48 timestamp);
 
     function getBlockUnitPriceAverage(
         uint8 orderBookId,

--- a/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketUserLogic.sol
@@ -118,7 +118,6 @@ library LendingMarketUserLogic {
             _side,
             filledAmount,
             filledOrder.futureValue,
-            filledOrder.unitPrice,
             feeInFV
         );
 
@@ -184,7 +183,6 @@ library LendingMarketUserLogic {
             side,
             filledOrder.amount,
             filledOrder.futureValue,
-            filledOrder.unitPrice,
             feeInFV
         );
 
@@ -214,7 +212,6 @@ library LendingMarketUserLogic {
         ProtocolTypes.Side _side,
         uint256 _filledAmount,
         uint256 _filledAmountInFV,
-        uint256 _filledUnitPrice,
         uint256 _feeInFV
     ) public {
         if (_filledAmountInFV != 0) {
@@ -232,7 +229,6 @@ library LendingMarketUserLogic {
             LendingMarketOperationLogic.updateOrderLogs(
                 _ccy,
                 _maturity,
-                _filledUnitPrice,
                 _filledAmount,
                 _filledAmountInFV
             );

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -73,11 +73,13 @@ library OrderBookLogic {
         preOpeningDate = orderBook.preOpeningDate;
     }
 
-    function getLastOrderBlockNumber(uint8 _orderBookId) external view returns (uint256) {
-        return _getOrderBook(_orderBookId).lastOrderBlockNumber;
+    function getLastOrderTimestamp(uint8 _orderBookId) external view returns (uint48) {
+        return _getOrderBook(_orderBookId).lastOrderTimestamp;
     }
 
-    function getBlockUnitPriceHistory(uint8 _orderBookId) external view returns (uint256[] memory) {
+    function getBlockUnitPriceHistory(
+        uint8 _orderBookId
+    ) external view returns (uint256[] memory unitPrices, uint48 timestamp) {
         return _getOrderBook(_orderBookId).getBlockUnitPriceHistory(true);
     }
 

--- a/contracts/protocol/storages/LendingMarketControllerStorage.sol
+++ b/contracts/protocol/storages/LendingMarketControllerStorage.sol
@@ -30,7 +30,6 @@ library LendingMarketControllerStorage {
         mapping(bytes32 ccy => mapping(address user => EnumerableSet.UintSet maturities)) usedMaturities;
         // Observation period logs that is used for auto-rolls
         mapping(bytes32 ccy => mapping(uint256 maturity => ObservationPeriodLog log)) observationPeriodLogs;
-        mapping(bytes32 ccy => mapping(uint256 maturity => uint256 unitPrice)) estimatedAutoRollUnitPrice;
         // List of currency that the user has open orders or positions
         mapping(address user => EnumerableSet.Bytes32Set currency) usedCurrencies;
         mapping(address user => bool isRedeemed) isRedeemed;

--- a/test/unit/lending-market-controller/operations.test.ts
+++ b/test/unit/lending-market-controller/operations.test.ts
@@ -174,8 +174,8 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.bestLendUnitPrice).to.equal('10000');
       expect(detail.bestBorrowUnitPrice).to.equal('0');
       expect(detail.marketUnitPrice).to.equal('0');
-      expect(detail.lastOrderBlockNumber).to.equal('0');
       expect(detail.blockUnitPriceHistory[0]).to.equal('0');
+      expect(detail.lastBlockUnitPriceTimestamp).to.equal('0');
       expect(detail.maxLendUnitPrice).to.equal('10000');
       expect(detail.minBorrowUnitPrice).to.equal('1');
       expect(detail.openingUnitPrice).to.equal('0');
@@ -236,6 +236,10 @@ describe('LendingMarketController - Operations', () => {
           '8000',
         );
 
+      await tx.wait();
+      const { timestamp: lastBlockUnitPriceTimestamp } =
+        await ethers.provider.getBlock(tx.blockNumber);
+
       await ethers.provider.send('evm_mine', []);
 
       const detail = await lendingMarketReader.getOrderBookDetail(
@@ -246,8 +250,10 @@ describe('LendingMarketController - Operations', () => {
       expect(detail.bestLendUnitPrice).to.equal('9000');
       expect(detail.bestBorrowUnitPrice).to.equal('5000');
       expect(detail.marketUnitPrice).to.equal('8000');
-      expect(detail.lastOrderBlockNumber).to.equal(tx.blockNumber);
       expect(detail.blockUnitPriceHistory[0]).to.equal('8000');
+      expect(detail.lastBlockUnitPriceTimestamp).to.equal(
+        lastBlockUnitPriceTimestamp,
+      );
       expect(detail.maxLendUnitPrice).to.equal('8800');
       expect(detail.minBorrowUnitPrice).to.equal('7600');
       expect(detail.openingUnitPrice).to.equal('0');
@@ -255,13 +261,15 @@ describe('LendingMarketController - Operations', () => {
 
       const minDebtUnitPrice =
         await lendingMarketControllerProxy.getMinDebtUnitPrice(targetCurrency);
-      const { timestamp } = await ethers.provider.getBlock('latest');
+      const { timestamp: latestTimestamp } = await ethers.provider.getBlock(
+        'latest',
+      );
 
       expect(detail.currentMinDebtUnitPrice).to.equal(
         BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE).sub(
           BigNumber.from(BASE_MIN_DEBT_UNIT_PRICE)
             .sub(minDebtUnitPrice)
-            .mul(maturities[0].sub(timestamp))
+            .mul(maturities[0].sub(latestTimestamp))
             .div(SECONDS_IN_YEAR),
         ),
       );

--- a/test/unit/lending-market/orders.test.ts
+++ b/test/unit/lending-market/orders.test.ts
@@ -92,7 +92,7 @@ describe('LendingMarket - Orders', () => {
           unitPrice,
         );
 
-      return tx.blockNumber;
+      return tx;
     };
 
     const checkBlockUnitPrice = async (
@@ -109,28 +109,32 @@ describe('LendingMarket - Orders', () => {
     };
 
     const checkBlockUnitPriceHistory = async (unitPrices: string[]) => {
-      const blockUnitPriceHistory =
-        await lendingMarket.getBlockUnitPriceHistory(currentOrderBookId);
+      const history = await lendingMarket.getBlockUnitPriceHistory(
+        currentOrderBookId,
+      );
 
-      expect(blockUnitPriceHistory.length).to.equal(5);
-      expect(blockUnitPriceHistory[0]).to.equal(unitPrices[0] || '0');
-      expect(blockUnitPriceHistory[1]).to.equal(unitPrices[1] || '0');
-      expect(blockUnitPriceHistory[2]).to.equal(unitPrices[2] || '0');
-      expect(blockUnitPriceHistory[3]).to.equal(unitPrices[3] || '0');
-      expect(blockUnitPriceHistory[4]).to.equal(unitPrices[4] || '0');
+      expect(history.unitPrices.length).to.equal(5);
+      expect(history.unitPrices[0]).to.equal(unitPrices[0] || '0');
+      expect(history.unitPrices[1]).to.equal(unitPrices[1] || '0');
+      expect(history.unitPrices[2]).to.equal(unitPrices[2] || '0');
+      expect(history.unitPrices[3]).to.equal(unitPrices[3] || '0');
+      expect(history.unitPrices[4]).to.equal(unitPrices[4] || '0');
     };
 
     it('Check with a single order', async () => {
-      const blockNumber = await fillOrder('100000000000000', '8000');
+      const tx = await fillOrder('100000000000000', '8000');
 
       await checkBlockUnitPrice('8000', '8000');
       await checkBlockUnitPriceHistory(['8000']);
 
-      const lastOrderBlockNumber = await lendingMarket.getLastOrderBlockNumber(
+      const lastOrderTimestamp = await lendingMarket.getLastOrderTimestamp(
         currentOrderBookId,
       );
 
-      expect(blockNumber).to.equal(lastOrderBlockNumber);
+      await tx.wait();
+      const { timestamp } = await ethers.provider.getBlock(tx.blockNumber);
+
+      expect(timestamp).to.equal(lastOrderTimestamp);
     });
 
     it('Check with multiple orders in the same block', async () => {


### PR DESCRIPTION
- Change the auto-roll price discovery mechanism to use the last block unit price instead of the last order unit price.
- Change the storage data, `lastOrderBlockNumber`, in `OrderBookLib` to `lastOrderTimestamp` for the mechanism change above.