### PR TITLE
refactor: remove unused code in _fillOrders [SF-907]

### DIFF
--- a/contracts/protocol/libraries/logics/OrderActionLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderActionLogic.sol
@@ -473,7 +473,6 @@ library OrderActionLogic {
 
         (filledOrder, partiallyFilledOrder, vars.remainingAmount, vars.orderExists) = orderBook
             .fillOrders(_side, _amount, 0, _unitPrice);
-        filledOrder.amount = _amount - vars.remainingAmount;
 
         if (vars.remainingAmount > 0) {
             if (_ignoreRemainingAmount) {


### PR DESCRIPTION
- Remove unused code in `OrderActionLogic._fillOrders()`.