### PR TITLE
ci: add an environment variable to skip tests on a fork [SF-1016]

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -53,6 +53,7 @@ SAFE_API_URL=https://safe-transaction-mainnet.safe.global
 RELAYER_API_KEY=
 RELAYER_API_SECRET=
 ETHERSCAN_API_KEY=
+SKIP_TEST_ON_FORK=
 
 # Target chain's native token settings
 NATIVE_CURRENCY_SYMBOL=

--- a/.github/workflows/update-smart-contracts.yml
+++ b/.github/workflows/update-smart-contracts.yml
@@ -26,6 +26,7 @@ jobs:
     name: Test on a Fork
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.network }}
+    if: ${{ vars.SKIP_TEST_ON_FORK != 'true' }}
     outputs:
       diff: ${{ steps.diff.outputs.count }}
     steps:


### PR DESCRIPTION
This feature to skip tests on a fork is needed for a case where something happens in Tenderly or something like that. 
(For example, fork chains of Arbitrum Sepolia is not stable now and it prevents the deployment.)