### PR TITLE
feat: remove the order book reuse logic [SF-941]

### DIFF
--- a/contracts/mocks/protocol/LendingMarketCaller.sol
+++ b/contracts/mocks/protocol/LendingMarketCaller.sol
@@ -52,15 +52,11 @@ contract LendingMarketCaller {
         bytes32 _ccy,
         uint8 _maturedOrderBookId,
         uint8 _destinationOrderBookId,
-        uint256 _newMaturity,
-        uint256 _openingDate,
         uint256 _autoRollUnitPrice
     ) external {
         ILendingMarket(lendingMarkets[_ccy]).executeAutoRoll(
             _maturedOrderBookId,
             _destinationOrderBookId,
-            _newMaturity,
-            _openingDate,
             _autoRollUnitPrice
         );
     }

--- a/contracts/protocol/FutureValueVault.sol
+++ b/contracts/protocol/FutureValueVault.sol
@@ -183,8 +183,7 @@ contract FutureValueVault is IFutureValueVault, MixinAddressResolver, Proxyable 
      */
     function reset(
         uint8 _orderBookId,
-        address _user,
-        uint256 _activeMaturity
+        address _user
     )
         external
         override
@@ -192,13 +191,10 @@ contract FutureValueVault is IFutureValueVault, MixinAddressResolver, Proxyable 
         returns (int256 removedAmount, int256 currentAmount, uint256 maturity, bool isAllRemoved)
     {
         currentAmount = Storage.slot().balances[_orderBookId][_user];
+        maturity = Storage.slot().balanceMaturities[_orderBookId][_user];
 
-        if (
-            Storage.slot().balanceMaturities[_orderBookId][_user] != _activeMaturity &&
-            currentAmount != 0
-        ) {
+        if (maturity < block.timestamp && currentAmount != 0) {
             removedAmount = currentAmount;
-            maturity = Storage.slot().balanceMaturities[_orderBookId][_user];
 
             isAllRemoved = false;
             if (removedAmount >= 0) {

--- a/contracts/protocol/LendingMarket.sol
+++ b/contracts/protocol/LendingMarket.sol
@@ -597,15 +597,11 @@ contract LendingMarket is ILendingMarket, MixinAddressResolver, Pausable, Proxya
     function executeAutoRoll(
         uint8 _maturedOrderBookId,
         uint8 _newNearestOrderBookId,
-        uint256 _newMaturity,
-        uint256 _openingDate,
         uint256 _autoRollUnitPrice
     ) external override onlyLendingMarketController {
         OrderBookLogic.executeAutoRoll(
             _maturedOrderBookId,
             _newNearestOrderBookId,
-            _newMaturity,
-            _openingDate,
             _autoRollUnitPrice
         );
     }

--- a/contracts/protocol/interfaces/IFutureValueVault.sol
+++ b/contracts/protocol/interfaces/IFutureValueVault.sol
@@ -44,8 +44,7 @@ interface IFutureValueVault {
 
     function reset(
         uint8 orderBookId,
-        address user,
-        uint256 activeMaturity
+        address user
     )
         external
         returns (int256 removedAmount, int256 currentAmount, uint256 maturity, bool isAllRemoved);

--- a/contracts/protocol/interfaces/ILendingMarket.sol
+++ b/contracts/protocol/interfaces/ILendingMarket.sol
@@ -196,8 +196,6 @@ interface ILendingMarket {
     function executeAutoRoll(
         uint8 maturedOrderBookId,
         uint8 newNearestOrderBookId,
-        uint256 newMaturity,
-        uint256 openingDate,
         uint256 autoRollUnitPrice
     ) external;
 

--- a/contracts/protocol/libraries/OrderBookLib.sol
+++ b/contracts/protocol/libraries/OrderBookLib.sol
@@ -37,7 +37,6 @@ library OrderBookLib {
     uint256 public constant CIRCUIT_BREAKER_MINIMUM_BORROW_RANGE = 200;
 
     error EmptyOrderBook();
-    error PastMaturityOrderExists();
 
     struct OrderBook {
         uint256 maturity;
@@ -54,6 +53,8 @@ library OrderBookLib {
         mapping(address user => uint48[] orderIds) activeLendOrderIds;
         mapping(address user => uint48[] orderIds) activeBorrowOrderIds;
         // Maturity when user last executes order
+        // NOTE: Deprecated due to discontinuation of order book rotation
+        // However, this old storage must be kept as it is for backward compatibility due to contract upgrade limitations.
         mapping(address user => uint256 maturity) userCurrentMaturities;
         // Micro slots for order
         mapping(uint48 orderId => uint256 slots) orders;
@@ -305,8 +306,8 @@ library OrderBookLib {
     ) internal view returns (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) {
         uint256 activeOrderCount = 0;
         uint256 inActiveOrderCount = 0;
-        uint256 userMaturity = self.userCurrentMaturities[_user];
-        bool isPastMaturity = userMaturity != self.maturity;
+        uint256 currentMaturity = self.maturity;
+        bool isPastMaturity = block.timestamp >= currentMaturity;
 
         uint48[] memory orderIds = self.activeLendOrderIds[_user];
         uint256 orderIdLength = orderIds.length;
@@ -317,7 +318,7 @@ library OrderBookLib {
             uint48 orderId = orderIds[i];
             (, uint256 unitPrice, , ) = _unpackOrder(self.orders[orderId]);
 
-            if (!self.lendOrders[userMaturity].isActiveOrderId(unitPrice, orderId)) {
+            if (!self.lendOrders[currentMaturity].isActiveOrderId(unitPrice, orderId)) {
                 unchecked {
                     inActiveOrderCount += 1;
                 }
@@ -347,8 +348,8 @@ library OrderBookLib {
     ) internal view returns (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) {
         uint256 activeOrderCount = 0;
         uint256 inActiveOrderCount = 0;
-        uint256 userMaturity = self.userCurrentMaturities[_user];
-        bool isPastMaturity = userMaturity != self.maturity;
+        uint256 currentMaturity = self.maturity;
+        bool isPastMaturity = block.timestamp >= currentMaturity;
 
         uint48[] memory orderIds = self.activeBorrowOrderIds[_user];
         uint256 orderIdLength = orderIds.length;
@@ -359,7 +360,7 @@ library OrderBookLib {
             uint48 orderId = orderIds[i];
             (, uint256 unitPrice, , ) = _unpackOrder(self.orders[orderId]);
 
-            if (!self.borrowOrders[userMaturity].isActiveOrderId(unitPrice, orderId)) {
+            if (!self.borrowOrders[currentMaturity].isActiveOrderId(unitPrice, orderId)) {
                 unchecked {
                     inActiveOrderCount += 1;
                 }
@@ -409,22 +410,6 @@ library OrderBookLib {
                     0,
                     _unitPrice
                 );
-        }
-    }
-
-    function updateUserMaturity(OrderBook storage self, address _user) internal {
-        uint256 userMaturity = self.userCurrentMaturities[_user];
-        uint256 orderBookMaturity = self.maturity;
-
-        if (userMaturity != orderBookMaturity) {
-            if (
-                self.activeLendOrderIds[_user].length > 0 ||
-                self.activeBorrowOrderIds[_user].length > 0
-            ) {
-                revert PastMaturityOrderExists();
-            }
-
-            self.userCurrentMaturities[_user] = orderBookMaturity;
         }
     }
 

--- a/contracts/protocol/libraries/logics/OrderActionLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderActionLogic.sol
@@ -140,7 +140,7 @@ library OrderActionLogic {
         )
     {
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
-        maturity = orderBook.userCurrentMaturities[_user];
+        maturity = orderBook.maturity;
 
         uint48[] memory lendOrderIds;
         uint48[] memory borrowOrderIds;
@@ -202,7 +202,6 @@ library OrderActionLogic {
         if (_amount == 0) revert InvalidAmount();
 
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
-        orderBook.updateUserMaturity(_user);
 
         ExecuteOrderVars memory vars;
         vars.maturity = orderBook.maturity;
@@ -286,7 +285,6 @@ library OrderActionLogic {
         if (_amount == 0) revert InvalidAmount();
 
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
-        orderBook.updateUserMaturity(_user);
 
         if (
             (_side == ProtocolTypes.Side.LEND && orderBook.hasBorrowOrder(_user)) ||

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -237,20 +237,13 @@ library OrderBookLogic {
     function executeAutoRoll(
         uint8 _maturedOrderBookId,
         uint8 _destinationOrderBookId,
-        uint256 _newMaturity,
-        uint256 _openingDate,
         uint256 _autoRollUnitPrice
     ) external {
         OrderBookLib.OrderBook storage maturedOrderBook = Storage.slot().orderBooks[
             _maturedOrderBookId
         ];
-        if (!maturedOrderBook.isMatured()) revert OrderBookNotMatured();
 
-        Storage.slot().isReady[_newMaturity] = maturedOrderBook.initialize(
-            _newMaturity,
-            _openingDate,
-            _openingDate - OrderBookLib.PRE_ORDER_BASE_PERIOD
-        );
+        if (!maturedOrderBook.isMatured()) revert OrderBookNotMatured();
 
         OrderBookLib.OrderBook storage destinationOrderBook = Storage.slot().orderBooks[
             _destinationOrderBookId

--- a/contracts/protocol/libraries/logics/OrderReaderLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderReaderLogic.sol
@@ -70,7 +70,7 @@ library OrderReaderLogic {
 
         (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) = orderBook
             .getLendOrderIds(_user);
-        maturity = orderBook.userCurrentMaturities[_user];
+        maturity = orderBook.maturity;
 
         for (uint256 i; i < activeOrderIds.length; ) {
             PlacedOrder memory order = orderBook.getOrder(activeOrderIds[i]);
@@ -123,7 +123,7 @@ library OrderReaderLogic {
 
         (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) = orderBook
             .getBorrowOrderIds(_user);
-        maturity = orderBook.userCurrentMaturities[_user];
+        maturity = orderBook.maturity;
 
         for (uint256 i; i < activeOrderIds.length; ) {
             // Sum future values in the current maturity.

--- a/contracts/protocol/storages/FutureValueVaultStorage.sol
+++ b/contracts/protocol/storages/FutureValueVaultStorage.sol
@@ -9,6 +9,8 @@ library FutureValueVaultStorage {
         // Mapping from user to balances per order book id
         mapping(uint8 orderBookId => mapping(address user => int256 balance)) balances;
         // Maturity when the user receives the balance on the target order book
+        // NOTE: Now maturities don't need to be sorted per user because the user can have only one balance per maturity.
+        // However, this storage must be kept to be used as it is for backward compatibility due to contract upgrade limitations.
         mapping(uint8 orderBookId => mapping(address user => uint256 maturity)) balanceMaturities;
         // Total lending amount supplied per maturity
         mapping(uint256 maturity => uint256 amount) totalLendingSupplies;

--- a/contracts/protocol/storages/LendingMarketStorage.sol
+++ b/contracts/protocol/storages/LendingMarketStorage.sol
@@ -21,6 +21,9 @@ library LendingMarketStorage {
         uint256 orderFeeRate;
         // Rate limit range of yield for the circuit breaker
         uint256 circuitBreakerLimitRange;
+        // Mapping from order book id to order book
+        // NOTE: Now maturities can be a key to order books instead of order book ids because order books don't be reused by auto rolls.
+        // However, this storage must be kept to be used as it is for backward compatibility due to contract upgrade limitations.
         mapping(uint8 orderBookId => OrderBookLib.OrderBook orderBook) orderBooks;
         mapping(uint256 maturity => bool isReady) isReady;
         mapping(uint256 maturity => ItayoseLog log) itayoseLogs;

--- a/test/unit/lending-market-controller/operations.test.ts
+++ b/test/unit/lending-market-controller/operations.test.ts
@@ -957,17 +957,27 @@ describe('LendingMarketController - Operations', () => {
             '7900',
           );
 
+        await time.increaseTo(maturities[0].sub(3600).toString());
+
+        const funds = await lendingMarketControllerProxy.calculateFunds(
+          targetCurrency,
+          alice.address,
+          LIQUIDATION_THRESHOLD_RATE,
+        );
+
+        expect(funds.workingLendOrdersAmount).to.equal('100000000000000000');
+        expect(funds.workingBorrowOrdersAmount).to.equal('36000000000000000');
+
         await time.increaseTo(maturities[0].toString());
 
-        const { workingLendOrdersAmount, workingBorrowOrdersAmount } =
-          await lendingMarketControllerProxy.calculateFunds(
-            targetCurrency,
-            alice.address,
-            LIQUIDATION_THRESHOLD_RATE,
-          );
+        const funds2 = await lendingMarketControllerProxy.calculateFunds(
+          targetCurrency,
+          alice.address,
+          LIQUIDATION_THRESHOLD_RATE,
+        );
 
-        expect(workingLendOrdersAmount).to.equal('100000000000000000');
-        expect(workingBorrowOrdersAmount).to.equal('36000000000000000');
+        expect(funds2.workingLendOrdersAmount).to.equal('0');
+        expect(funds2.workingBorrowOrdersAmount).to.equal('0');
       });
 
       it('Calculate the total funds with position less than min debt unit price', async () => {

--- a/test/unit/lending-market-controller/orders.test.ts
+++ b/test/unit/lending-market-controller/orders.test.ts
@@ -771,7 +771,7 @@ describe('LendingMarketController - Orders', () => {
         await lendingMarketControllerProxy.getMaturities(targetCurrency);
       const rotatedMarket = await lendingMarketReader.getOrderBookDetail(
         targetCurrency,
-        maturities[0],
+        newMaturity,
       );
 
       // Check borrow rates

--- a/test/unit/lending-market/auto-rolls.test.ts
+++ b/test/unit/lending-market/auto-rolls.test.ts
@@ -68,22 +68,10 @@ describe('LendingMarket - Auto-rolls', () => {
 
     await time.increaseTo(maturity);
 
-    const { timestamp: newTimestamp } = await ethers.provider.getBlock(
-      'latest',
-    );
-    const newMaturity = moment(newTimestamp * 1000)
-      .add(1, 'M')
-      .unix();
-    const newOpeningDate = moment(newTimestamp * 1000)
-      .add(48, 'h')
-      .unix();
-
     await lendingMarketCaller.executeAutoRoll(
       targetCurrency,
       currentOrderBookId,
       currentOrderBookId,
-      newMaturity,
-      newOpeningDate,
       10000,
     );
   });
@@ -94,8 +82,6 @@ describe('LendingMarket - Auto-rolls', () => {
         targetCurrency,
         currentOrderBookId,
         currentOrderBookId,
-        1,
-        1,
         10000,
       ),
     ).revertedWith('OrderBookNotMatured');
@@ -106,8 +92,6 @@ describe('LendingMarket - Auto-rolls', () => {
       lendingMarket.executeAutoRoll(
         currentOrderBookId,
         currentOrderBookId,
-        1,
-        1,
         10000,
       ),
     ).revertedWith('OnlyAcceptedContract("LendingMarketController")');


### PR DESCRIPTION
- Remove the reuse logic of order books for auto-rolls.
- Add logic to create a new order book per auto-rolls