### PR TITLE
fix: fix lastOrderBookId overflow bug [SF-1079]

### DIFF
--- a/contracts/protocol/FutureValueVault.sol
+++ b/contracts/protocol/FutureValueVault.sol
@@ -257,7 +257,7 @@ contract FutureValueVault is IFutureValueVault, MixinAddressResolver, Proxyable 
         currentAmount = Storage.slot().balances[_orderBookId][_user];
         maturity = Storage.slot().balanceMaturities[_orderBookId][_user];
 
-        if (maturity < block.timestamp && currentAmount != 0) {
+        if (maturity <= block.timestamp && currentAmount != 0) {
             removedAmount = currentAmount;
 
             isAllRemoved = false;

--- a/contracts/protocol/FutureValueVault.sol
+++ b/contracts/protocol/FutureValueVault.sol
@@ -257,7 +257,7 @@ contract FutureValueVault is IFutureValueVault, MixinAddressResolver, Proxyable 
         currentAmount = Storage.slot().balances[_orderBookId][_user];
         maturity = Storage.slot().balanceMaturities[_orderBookId][_user];
 
-        if (maturity <= block.timestamp && currentAmount != 0) {
+        if (currentAmount != 0) {
             removedAmount = currentAmount;
 
             isAllRemoved = false;

--- a/contracts/protocol/GenesisValueVault.sol
+++ b/contracts/protocol/GenesisValueVault.sol
@@ -100,24 +100,6 @@ contract GenesisValueVault is IGenesisValueVault, MixinAddressResolver, Proxyabl
     }
 
     /**
-     * @notice Gets the future value of the user balance.
-     * @param _ccy Currency name in bytes32
-     * @param _user User's address
-     * @return The future value of the user balance
-     */
-    function getBalanceInFutureValue(
-        bytes32 _ccy,
-        address _user
-    ) external view override returns (int256) {
-        // NOTE: The formula is:
-        // futureValue = genesisValue * currentCompoundFactor.
-        return
-            (getBalance(_ccy, _user) * getLendingCompoundFactor(_ccy).toInt256()).div(
-                (10 ** decimals(_ccy)).toInt256()
-            );
-    }
-
-    /**
      * @notice Gets the current total supply per maturity
      * @param _ccy Currency name in bytes32
      * @param _maturity The maturity

--- a/contracts/protocol/interfaces/IGenesisValueVault.sol
+++ b/contracts/protocol/interfaces/IGenesisValueVault.sol
@@ -39,8 +39,6 @@ interface IGenesisValueVault {
 
     function getBalance(bytes32 ccy, address user) external view returns (int256);
 
-    function getBalanceInFutureValue(bytes32 ccy, address user) external view returns (int256);
-
     function getMaturityGenesisValue(bytes32 ccy, uint256 maturity) external view returns (int256);
 
     function getCurrentMaturity(bytes32 ccy) external view returns (uint256);

--- a/contracts/protocol/interfaces/IGenesisValueVault.sol
+++ b/contracts/protocol/interfaces/IGenesisValueVault.sol
@@ -29,6 +29,8 @@ interface IGenesisValueVault {
     event BalanceLocked(bytes32 indexed ccy, address indexed user, uint256 value);
     event BalanceUnlocked(bytes32 indexed ccy, address indexed user, uint256 value);
 
+    function isAutoRolled(bytes32 _ccy, uint256 _maturity) external view returns (bool);
+
     function isInitialized(bytes32 ccy) external view returns (bool);
 
     function decimals(bytes32 ccy) external view returns (uint8);

--- a/contracts/protocol/libraries/logics/OrderActionLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderActionLogic.sol
@@ -146,7 +146,7 @@ library OrderActionLogic {
         )
     {
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
-        maturity = orderBook.maturity;
+        maturity = orderBook.userCurrentMaturities[_user];
 
         uint48[] memory lendOrderIds;
         uint48[] memory borrowOrderIds;
@@ -208,6 +208,7 @@ library OrderActionLogic {
         if (_amount == 0) revert InvalidAmount();
 
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
+        orderBook.updateUserMaturity(_user);
 
         ExecuteOrderVars memory vars;
         vars.maturity = orderBook.maturity;
@@ -299,6 +300,7 @@ library OrderActionLogic {
         if (_amount == 0) revert InvalidAmount();
 
         OrderBookLib.OrderBook storage orderBook = _getOrderBook(_orderBookId);
+        orderBook.updateUserMaturity(_user);
 
         if (
             (_side == ProtocolTypes.Side.LEND && orderBook.hasBorrowOrder(_user)) ||

--- a/contracts/protocol/libraries/logics/OrderBookLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderBookLogic.sol
@@ -327,7 +327,14 @@ library OrderBookLogic {
     }
 
     function _nextOrderBookId() internal returns (uint8) {
-        Storage.slot().lastOrderBookId++;
+        // NOTE: Originally, matured ordebooks were reused as new orderbooks after auto-rolls, but this reusing logic has been removed.
+        // This means that `orderBookId` is increased in proportion to the number of auto-rolls executed. To avoid overflow of `orderBookId`,
+        // `orderBookId` circulate between 1 and 255.
+        if (Storage.slot().lastOrderBookId == type(uint8).max) {
+            Storage.slot().lastOrderBookId = 1;
+        } else {
+            Storage.slot().lastOrderBookId++;
+        }
         return Storage.slot().lastOrderBookId;
     }
 

--- a/contracts/protocol/libraries/logics/OrderReaderLogic.sol
+++ b/contracts/protocol/libraries/logics/OrderReaderLogic.sol
@@ -70,7 +70,7 @@ library OrderReaderLogic {
 
         (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) = orderBook
             .getLendOrderIds(_user);
-        maturity = orderBook.maturity;
+        maturity = orderBook.userCurrentMaturities[_user];
 
         for (uint256 i; i < activeOrderIds.length; ) {
             PlacedOrder memory order = orderBook.getOrder(activeOrderIds[i]);
@@ -123,7 +123,7 @@ library OrderReaderLogic {
 
         (uint48[] memory activeOrderIds, uint48[] memory inActiveOrderIds) = orderBook
             .getBorrowOrderIds(_user);
-        maturity = orderBook.maturity;
+        maturity = orderBook.userCurrentMaturities[_user];
 
         for (uint256 i; i < activeOrderIds.length; ) {
             // Sum future values in the current maturity.

--- a/contracts/protocol/storages/FutureValueVaultStorage.sol
+++ b/contracts/protocol/storages/FutureValueVaultStorage.sol
@@ -9,8 +9,6 @@ library FutureValueVaultStorage {
         // Mapping from user to balances per order book id
         mapping(uint8 orderBookId => mapping(address user => int256 balance)) balances;
         // Maturity when the user receives the balance on the target order book
-        // NOTE: Now maturities don't need to be sorted per user because the user can have only one balance per maturity.
-        // However, this storage must be kept to be used as it is for backward compatibility due to contract upgrade limitations.
         mapping(uint8 orderBookId => mapping(address user => uint256 maturity)) balanceMaturities;
         // Total lending amount supplied per maturity
         mapping(uint256 maturity => uint256 amount) totalLendingSupplies;

--- a/contracts/protocol/storages/LendingMarketStorage.sol
+++ b/contracts/protocol/storages/LendingMarketStorage.sol
@@ -22,8 +22,6 @@ library LendingMarketStorage {
         // Rate limit range of yield for the circuit breaker
         uint256 circuitBreakerLimitRange;
         // Mapping from order book id to order book
-        // NOTE: Now maturities can be a key to order books instead of order book ids because order books don't be reused by auto rolls.
-        // However, this storage must be kept to be used as it is for backward compatibility due to contract upgrade limitations.
         mapping(uint8 orderBookId => OrderBookLib.OrderBook orderBook) orderBooks;
         mapping(uint256 maturity => bool isReady) isReady;
         mapping(uint256 maturity => ItayoseLog log) itayoseLogs;

--- a/test/unit/genesis-value-vault.test.ts
+++ b/test/unit/genesis-value-vault.test.ts
@@ -152,6 +152,10 @@ describe('GenesisValueVault', () => {
       );
       expect(autoRollLog.next).to.equals(0);
       expect(autoRollLog.prev).to.equals(0);
+
+      expect(
+        await genesisValueVaultProxy.isAutoRolled(targetCurrency, maturity),
+      ).to.false;
     });
 
     it('Fail to call initialization due to duplicate execution', async () => {
@@ -954,6 +958,10 @@ describe('GenesisValueVault', () => {
     });
 
     it('Execute auto-roll', async () => {
+      expect(
+        await genesisValueVaultProxy.isAutoRolled(targetCurrency, maturity),
+      ).to.false;
+
       await genesisValueVaultCaller.updateGenesisValueWithFutureValue(
         targetCurrency,
         alice.address,
@@ -1028,6 +1036,10 @@ describe('GenesisValueVault', () => {
       expect(autoRollLog.borrowingCompoundFactor).to.equals(
         borrowingCompoundFactor,
       );
+
+      expect(
+        await genesisValueVaultProxy.isAutoRolled(targetCurrency, maturity),
+      ).to.true;
     });
 
     it('Calculate the balance fluctuation of auto-rolls by on the current maturity', async () => {

--- a/test/unit/genesis-value-vault.test.ts
+++ b/test/unit/genesis-value-vault.test.ts
@@ -18,7 +18,6 @@ describe('GenesisValueVault', () => {
   let mockReserveFund: MockContract;
 
   let genesisValueVaultProxy: Contract;
-  ReserveFund;
   let genesisValueVaultCaller: Contract;
 
   let owner: SignerWithAddress;
@@ -380,16 +379,20 @@ describe('GenesisValueVault', () => {
           await genesisValueVaultProxy.getTotalLendingSupply(targetCurrency);
         const totalBorrowingSupply =
           await genesisValueVaultProxy.getTotalBorrowingSupply(targetCurrency);
-        const aliceBalanceInFV =
-          await genesisValueVaultProxy.getBalanceInFutureValue(
-            targetCurrency,
-            alice.address,
-          );
         const maturityBalance =
           await genesisValueVaultProxy.getMaturityGenesisValue(
             targetCurrency,
             maturity,
           );
+        const aliceBalance = await genesisValueVaultProxy.getBalance(
+          targetCurrency,
+          alice.address,
+        );
+        const aliceBalanceInFV = await genesisValueVaultProxy.calculateFVFromGV(
+          targetCurrency,
+          0,
+          aliceBalance,
+        );
 
         expect(totalLendingSupply).to.equals(
           fvAmount


### PR DESCRIPTION
- Add a logic to rotate `lastOrderBookId` values when it reaches the maximum value of uint8.
- Revert some logic that is related to `lastOrderBookId` and `userMaturity`.