### PR TITLE
Sf 1083 gv issue after 197 years

### DIFF
--- a/contracts/protocol/GenesisValueVault.sol
+++ b/contracts/protocol/GenesisValueVault.sol
@@ -227,7 +227,13 @@ contract GenesisValueVault is IGenesisValueVault, MixinAddressResolver, Proxyabl
         // NOTE: The formula is: genesisValue = featureValue / compoundFactor.
         bool isPlus = _futureValue > 0;
         uint256 absFv = (isPlus ? _futureValue : -_futureValue).toUint256();
-        uint256 absGv = (absFv * 10 ** decimals(_ccy)).div(compoundFactor);
+        uint256 absGv = Math.mulDiv(
+            absFv,
+            10 ** decimals(_ccy),
+            compoundFactor,
+            Math.Rounding.Down
+        );
+
         return isPlus ? absGv.toInt256() : -(absGv.toInt256());
     }
 
@@ -248,9 +254,10 @@ contract GenesisValueVault is IGenesisValueVault, MixinAddressResolver, Proxyabl
 
         if (compoundFactor == 0) revert NoCompoundFactorExists({maturity: _basisMaturity});
 
+        // NOTE: The formula is: featureValue = genesisValue * compoundFactor.
         bool isPlus = _genesisValue > 0;
         uint256 absGv = (isPlus ? _genesisValue : -_genesisValue).toUint256();
-        uint256 absFv = (absGv * compoundFactor).div(10 ** decimals(_ccy));
+        uint256 absFv = Math.mulDiv(absGv, compoundFactor, 10 ** decimals(_ccy), Math.Rounding.Up);
 
         return isPlus ? absFv.toInt256() : -(absFv.toInt256());
     }
@@ -528,6 +535,7 @@ contract GenesisValueVault is IGenesisValueVault, MixinAddressResolver, Proxyabl
     /**
      * @notice Forces a reset of the user's genesis value.
      * @param _ccy Currency name in bytes32
+     * @param _maturity The maturity
      * @param _user User's address
      * @param _amountInFV The amount in the future value to reset
      */

--- a/contracts/protocol/libraries/logics/LiquidationLogic.sol
+++ b/contracts/protocol/libraries/logics/LiquidationLogic.sol
@@ -21,7 +21,6 @@ library LiquidationLogic {
     error NoDebt(address user, bytes32 ccy, uint256 maturity);
     error NoLiquidationAmount(address user, bytes32 ccy);
     error InvalidLiquidation();
-    error InvalidRepaymentAmount();
     error InvalidCurrency(bytes32 ccy);
     error NotRepaymentPeriod();
 
@@ -326,14 +325,12 @@ library LiquidationLogic {
             liquidationAmountInDebtCcy
         );
 
-        if (repaymentAmount != liquidationAmountInDebtCcy) revert InvalidRepaymentAmount();
-
         emit ForcedRepaymentExecuted(
             _user,
             _collateralCcy,
             _debtCcy,
             _debtMaturity,
-            liquidationAmountInDebtCcy
+            repaymentAmount
         );
     }
 

--- a/test/common/orders.ts
+++ b/test/common/orders.ts
@@ -135,3 +135,39 @@ export const calculateAutoRolledBorrowingCompoundFactor = (
       .toFixed(),
   );
 };
+
+export const calculateFVFromFV = (
+  futureValue: BigNumber,
+  compoundFactorFrom: BigNumber,
+  compoundFactorTo: BigNumber,
+  gvDecimals: number,
+) => {
+  const gvDigit = BigNumberJS(10).pow(gvDecimals.toString());
+
+  return BigNumber.from(
+    BigNumberJS(futureValue.toString())
+      .times(gvDigit)
+      .div(compoundFactorFrom.toString())
+      .dp(0, BigNumberJS.ROUND_DOWN)
+      .times(compoundFactorTo.toString())
+      .div(gvDigit)
+      .dp(0, BigNumberJS.ROUND_UP)
+      .toFixed(),
+  );
+};
+
+export const calculateGVFromFV = (
+  futureValue: BigNumber,
+  compoundFactor: BigNumber,
+  gvDecimals: number,
+) => {
+  const gvDigit = BigNumberJS(10).pow(gvDecimals.toString());
+
+  return BigNumber.from(
+    BigNumberJS(futureValue.toString())
+      .times(gvDigit)
+      .div(compoundFactor.toString())
+      .dp(0, BigNumberJS.ROUND_DOWN)
+      .toFixed(),
+  );
+};

--- a/test/integration/auto-rolls.test.ts
+++ b/test/integration/auto-rolls.test.ts
@@ -1,6 +1,5 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { time } from '@openzeppelin/test-helpers';
-import BigNumberJS from 'bignumber.js';
 import { expect } from 'chai';
 import { BigNumber, Contract } from 'ethers';
 import { ethers } from 'hardhat';
@@ -18,7 +17,9 @@ import { deployContracts } from '../common/deployment';
 import { formatOrdinals } from '../common/format';
 import {
   calculateAutoRolledLendingCompoundFactor,
+  calculateFVFromFV,
   calculateFutureValue,
+  calculateGVFromFV,
   calculateOrderFee,
 } from '../common/orders';
 import { Signers } from '../common/signers';
@@ -300,18 +301,10 @@ describe('Integration Test: Auto-rolls', async () => {
       const gvDecimals = await genesisValueVault.decimals(hexETH);
 
       expect(aliceFVAfter).to.equal(
-        BigNumberJS(aliceFVBefore.toString())
-          .times(lendingCF1.toString())
-          .div(lendingCF0.toString())
-          .dp(0)
-          .toFixed(),
+        calculateFVFromFV(aliceFVBefore, lendingCF0, lendingCF1, gvDecimals),
       );
       expect(aliceGVAfter).to.equal(
-        BigNumberJS(aliceFVBefore.toString())
-          .times(BigNumberJS(10).pow(gvDecimals.toString()))
-          .div(lendingCF0.toString())
-          .dp(0)
-          .toFixed(),
+        calculateGVFromFV(aliceFVBefore, lendingCF0, gvDecimals),
       );
 
       // Check the saved unit price and compound factor per maturity
@@ -360,15 +353,17 @@ describe('Integration Test: Auto-rolls', async () => {
         await genesisValueVault.getAutoRollLog(hexETH, maturities[0]);
       const { lendingCompoundFactor: lendingCF1 } =
         await genesisValueVault.getAutoRollLog(hexETH, maturities[1]);
+      const gvDecimals = await genesisValueVault.decimals(hexETH);
 
       expect(
         aliceFVAfter
           .sub(
-            BigNumberJS(aliceFVBefore.toString())
-              .times(lendingCF1.toString())
-              .div(lendingCF0.toString())
-              .dp(0)
-              .toFixed(),
+            calculateFVFromFV(
+              aliceFVBefore,
+              lendingCF0,
+              lendingCF1,
+              gvDecimals,
+            ),
           )
           .abs(),
       ).lte(1);
@@ -581,12 +576,14 @@ describe('Integration Test: Auto-rolls', async () => {
       expect(
         aliceFV1After
           .sub(
-            BigNumberJS(aliceFV0Before.toString())
-              .times(lendingCF1.toString())
-              .div(lendingCF0.toString())
-              .plus(aliceFV1Before.toString())
-              .dp(0)
-              .toFixed(),
+            aliceFV1Before.add(
+              calculateFVFromFV(
+                aliceFV0Before,
+                lendingCF0,
+                lendingCF1,
+                await genesisValueVault.decimals(hexETH),
+              ),
+            ),
           )
           .abs(),
       ).lte(1);
@@ -726,12 +723,14 @@ describe('Integration Test: Auto-rolls', async () => {
       expect(
         aliceFV1After
           .sub(
-            BigNumberJS(aliceFV0Before.toString())
-              .times(lendingCF1.toString())
-              .div(lendingCF0.toString())
-              .plus(aliceFV1Before.toString())
-              .dp(0)
-              .toFixed(),
+            aliceFV1Before.add(
+              calculateFVFromFV(
+                aliceFV0Before,
+                lendingCF0,
+                lendingCF1,
+                await genesisValueVault.decimals(hexETH),
+              ),
+            ),
           )
           .abs(),
       ).lte(1);
@@ -836,12 +835,14 @@ describe('Integration Test: Auto-rolls', async () => {
         expect(
           aliceFV1After
             .sub(
-              BigNumberJS(aliceFV0Before.toString())
-                .times(lendingCF1.toString())
-                .div(lendingCF0.toString())
-                .plus(aliceFV1Before.toString())
-                .dp(0)
-                .toFixed(),
+              aliceFV1Before.add(
+                calculateFVFromFV(
+                  aliceFV0Before,
+                  lendingCF0,
+                  lendingCF1,
+                  await genesisValueVault.decimals(hexETH),
+                ),
+              ),
             )
             .abs(),
         ).lte(1);
@@ -1137,12 +1138,14 @@ describe('Integration Test: Auto-rolls', async () => {
       expect(
         aliceFV1After
           .sub(
-            BigNumberJS(aliceFV0Before.toString())
-              .times(lendingCF1.toString())
-              .div(lendingCF0.toString())
-              .plus(aliceFV1Before.toString())
-              .dp(0)
-              .toFixed(),
+            aliceFV1Before.add(
+              calculateFVFromFV(
+                aliceFV0Before,
+                lendingCF0,
+                lendingCF1,
+                await genesisValueVault.decimals(hexETH),
+              ),
+            ),
           )
           .abs(),
       ).lte(1);

--- a/test/unit/lending-market-controller/rotations.test.ts
+++ b/test/unit/lending-market-controller/rotations.test.ts
@@ -1,6 +1,5 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { time } from '@openzeppelin/test-helpers';
-import BigNumberJS from 'bignumber.js';
 import { expect } from 'chai';
 import { MockContract } from 'ethereum-waffle';
 import { BigNumber, Contract } from 'ethers';
@@ -19,6 +18,7 @@ import {
 import {
   calculateAutoRolledBorrowingCompoundFactor,
   calculateAutoRolledLendingCompoundFactor,
+  calculateFVFromFV,
 } from '../../common/orders';
 import { deployContracts } from './utils';
 
@@ -523,33 +523,32 @@ describe('LendingMarketController - Rotations', () => {
             .then(({ futureValue }) => futureValue),
         ),
       );
+      const gvDecimals = await genesisValueVaultProxy.decimals(targetCurrency);
 
       expect(aliceFVAfter).to.equal(
-        BigNumberJS(aliceFVBefore.toString())
-          .times(
-            calculateAutoRolledLendingCompoundFactor(
-              autoRollLogBefore.lendingCompoundFactor,
-              maturities[1].sub(maturities[0]),
-              8571,
-            ).toString(),
-          )
-          .div(autoRollLogBefore.lendingCompoundFactor.toString())
-          .dp(0)
-          .toFixed(),
+        calculateFVFromFV(
+          aliceFVBefore,
+          autoRollLogBefore.lendingCompoundFactor,
+          calculateAutoRolledLendingCompoundFactor(
+            autoRollLogBefore.lendingCompoundFactor,
+            maturities[1].sub(maturities[0]),
+            8571,
+          ),
+          gvDecimals,
+        ),
       );
 
       expect(bobFVAfter).to.equal(
-        BigNumberJS(bobFVBefore.toString())
-          .times(
-            calculateAutoRolledBorrowingCompoundFactor(
-              autoRollLogBefore.borrowingCompoundFactor,
-              maturities[1].sub(maturities[0]),
-              8571,
-            ).toString(),
-          )
-          .div(autoRollLogBefore.borrowingCompoundFactor.toString())
-          .dp(0)
-          .toFixed(),
+        calculateFVFromFV(
+          bobFVBefore,
+          autoRollLogBefore.borrowingCompoundFactor,
+          calculateAutoRolledBorrowingCompoundFactor(
+            autoRollLogBefore.borrowingCompoundFactor,
+            maturities[1].sub(maturities[0]),
+            8571,
+          ),
+          gvDecimals,
+        ),
       );
     });
 


### PR DESCRIPTION
This PR is based on https://github.com/Secured-Finance/contracts/pull/348.

- Use the `mulDiv` function of OpenZeppelin library for GV-related calculation in `GenesisValueVault` to avoid overflows by huge compound factor value such as a value after 197 years auto-rolls with 20% interest rate.
- Remove the check of the actual amount and input amount in the `executeForcedRepayment` function to accept the rounding error between those amounts.