### PR TITLE
fix: fix a zctoken decimals issue [SF-1101]

### DIFF
--- a/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
+++ b/contracts/protocol/libraries/logics/LendingMarketOperationLogic.sol
@@ -350,11 +350,13 @@ library LendingMarketOperationLogic {
 
         string memory symbol = string.concat("zc", tokenSymbol);
         string memory name = string.concat("ZC ", tokenSymbol);
-        uint8 decimals = IERC20Metadata(tokenAddress).decimals() + GENESIS_VALUE_BASE_DECIMALS;
+        uint8 decimals = IERC20Metadata(tokenAddress).decimals();
 
         // If the maturity is 0, the ZCToken is created as a perpetual one.
         // Otherwise, the ZCToken is created per maturity.
-        if (_maturity != 0) {
+        if (_maturity == 0) {
+            decimals += GENESIS_VALUE_BASE_DECIMALS;
+        } else {
             (uint256 year, uint256 month, ) = TimeLibrary.timestampToDate(_maturity);
 
             string memory formattedMaturity = string.concat(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "!/contracts/mocks/**/*"
   ],
   "scripts": {
-    "test": "hardhat test",
+    "test": "DOTENV_CONFIG_PATH=.env.test hardhat test",
     "test:unit": "DOTENV_CONFIG_PATH=.env.test hardhat test ./test/unit/*.test.ts ./test/unit/**/*.test.ts",
     "test:integration": "DOTENV_CONFIG_PATH=.env.test hardhat test ./test/integration/*.test.ts",
     "test:performance": "DOTENV_CONFIG_PATH=.env.test hardhat test ./test/performance/*.test.ts",

--- a/test/integration/tokenization.test.ts
+++ b/test/integration/tokenization.test.ts
@@ -148,9 +148,7 @@ describe('Integration Test: Tokenization', async () => {
 
       expect(tokenInfo.ccy).to.equal(hexETH);
       expect(tokenInfo.maturity).to.equal(maturities[0]);
-      expect(await token.decimals()).to.equal(
-        (await wETHToken.decimals()) + 18,
-      );
+      expect(await token.decimals()).to.equal(await wETHToken.decimals());
       expect(await token.asset()).to.equal(wETHToken.address);
       expect(await token.maturity()).to.equal(maturities[0]);
       expect(await token.name()).to.equal(
@@ -192,9 +190,7 @@ describe('Integration Test: Tokenization', async () => {
 
       expect(tokenInfo.ccy).to.equal(hexUSDC);
       expect(tokenInfo.maturity).to.equal(maturities[0]);
-      expect(await token.decimals()).to.equal(
-        (await usdcToken.decimals()) + 18,
-      );
+      expect(await token.decimals()).to.equal(await usdcToken.decimals());
       expect(await token.asset()).to.equal(usdcToken.address);
       expect(await token.maturity()).to.equal(maturities[0]);
       expect(await token.name()).to.equal(

--- a/test/unit/lending-market-controller/tokenization.test.ts
+++ b/test/unit/lending-market-controller/tokenization.test.ts
@@ -177,7 +177,7 @@ describe('LendingMarketController - Tokenization', () => {
           nextMaturity.unix(),
           tokenName,
           tokenSymbol,
-          24,
+          6,
           () => true,
         );
 
@@ -228,7 +228,7 @@ describe('LendingMarketController - Tokenization', () => {
           nextMaturity.unix(),
           tokenName,
           tokenSymbol,
-          24,
+          6,
           () => true,
         );
 


### PR DESCRIPTION
- Update the logic for determining decimals of ZCTokens to become the same as an underlying asset.