### PR TITLE
feat: reduce the zc token decimals [SF-1101]

### DIFF
--- a/contracts/protocol/GenesisValueVault.sol
+++ b/contracts/protocol/GenesisValueVault.sol
@@ -324,6 +324,21 @@ contract GenesisValueVault is IGenesisValueVault, MixinAddressResolver, Proxyabl
     }
 
     /**
+     * @notice Updates the decimals of the genesis value.
+     * @dev The decimals of ZCTokens were always 36 before the contract upgrade, but they were fixed
+     * to be configured individually. This is a tentative function that configures them manually.
+     * So, this function can be deleted once the decimals of ZCTokens are updated for all currencies.
+     * @param _ccy Currency name in bytes32
+     * @param _decimals Compound factor decimals
+     */
+    function updateDecimals(
+        bytes32 _ccy,
+        uint8 _decimals
+    ) external override onlyLendingMarketController {
+        Storage.slot().decimals[_ccy] = _decimals;
+    }
+
+    /**
      * @notice Executes the auto-roll.
      * @param _ccy Currency name in bytes32
      * @param _maturity Current maturity

--- a/contracts/protocol/LendingMarketController.sol
+++ b/contracts/protocol/LendingMarketController.sol
@@ -1032,14 +1032,14 @@ contract LendingMarketController is
     }
 
     /**
-     * @notice Creates a future value token for the selected currency and maturity.
+     * @notice Migrate the lending market to the new version.
      * @dev ZCTokens do not exist in markets that were deployed before the contract upgrade,
      * so they must be configured individually.
-     * This function can be deleted once the future value token is created for all currencies and maturities.
+     * This function can be deleted after executing for all currencies and maturities.
      * @param _ccy Currency name in bytes32
      * @param _maturity The maturity of the ZCToken
      */
-    function createZCToken(bytes32 _ccy, uint256 _maturity) external onlyOwner {
-        LendingMarketOperationLogic.createZCToken(_ccy, _maturity);
+    function migrateLendingMarket(bytes32 _ccy, uint256 _maturity) external onlyOwner {
+        LendingMarketOperationLogic.migrateLendingMarket(_ccy, _maturity);
     }
 }

--- a/contracts/protocol/interfaces/IGenesisValueVault.sol
+++ b/contracts/protocol/interfaces/IGenesisValueVault.sol
@@ -99,6 +99,8 @@ interface IGenesisValueVault {
 
     function updateInitialCompoundFactor(bytes32 ccy, uint256 unitPrice) external;
 
+    function updateDecimals(bytes32 _ccy, uint8 _decimals) external;
+
     function executeAutoRoll(
         bytes32 ccy,
         uint256 maturity,

--- a/test/unit/genesis-value-vault.test.ts
+++ b/test/unit/genesis-value-vault.test.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import BigNumberJS from 'bignumber.js';
 import { expect } from 'chai';
 import { MockContract } from 'ethereum-waffle';
 import { BigNumber, Contract } from 'ethers';
@@ -27,10 +28,10 @@ describe('GenesisValueVault', () => {
   let targetCurrency: string;
   let currencyIdx = 0;
 
-  const initialCompoundFactor = BigNumber.from(1000000);
+  const initialCompoundFactor = BigNumber.from('1000000000000000000');
   const maturity = 1;
   const nextMaturity = 86401;
-  const decimals = 4;
+  const decimals = 26;
   const fvAmount = BigNumber.from(2000000);
   const unitPrice = 8000;
 
@@ -115,8 +116,6 @@ describe('GenesisValueVault', () => {
 
   describe('Initialize', async () => {
     it('Initialize contract settings', async () => {
-      // const unitPrice = 5000;
-
       await genesisValueVaultCaller.initializeCurrencySetting(
         targetCurrency,
         decimals,
@@ -326,7 +325,11 @@ describe('GenesisValueVault', () => {
           await genesisValueVaultProxy.getLendingCompoundFactor(targetCurrency);
 
         expect(amount).to.equals(
-          gvAmount.mul(compoundFactor).div(BigNumber.from(10).pow(decimals)),
+          BigNumberJS(gvAmount.toString())
+            .times(compoundFactor.toString())
+            .div(10 ** decimals)
+            .dp(0, BigNumberJS.ROUND_UP)
+            .toFixed(),
         );
       });
 
@@ -343,7 +346,11 @@ describe('GenesisValueVault', () => {
           await genesisValueVaultProxy.getLendingCompoundFactor(targetCurrency);
 
         expect(amount).to.equals(
-          gvAmount.mul(compoundFactor).div(BigNumber.from(10).pow(decimals)),
+          BigNumberJS(gvAmount.toString())
+            .times(compoundFactor.toString())
+            .div(10 ** decimals)
+            .dp(0, BigNumberJS.ROUND_UP)
+            .toFixed(),
         );
       });
 

--- a/test/unit/lending-market-controller/orders.test.ts
+++ b/test/unit/lending-market-controller/orders.test.ts
@@ -58,6 +58,7 @@ describe('LendingMarketController - Orders', () => {
     genesisDate = getGenesisDate(timestamp * 1000);
 
     await mockCurrencyController.mock.currencyExists.returns(true);
+    await mockERC20.mock.decimals.returns(18);
   });
 
   before(async () => {
@@ -93,7 +94,6 @@ describe('LendingMarketController - Orders', () => {
     await mockTokenVault.mock.depositFrom.returns();
     await mockTokenVault.mock.depositWithPermitFrom.returns();
     await mockTokenVault.mock.getTokenAddress.returns(mockERC20.address);
-    await mockERC20.mock.decimals.returns(18);
   });
 
   describe('Initialization', async () => {
@@ -149,6 +149,21 @@ describe('LendingMarketController - Orders', () => {
             MIN_DEBT_UNIT_PRICE,
           ),
       ).revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('Fail to initialize the lending market due to too many token decimals', async () => {
+      await mockERC20.mock.decimals.returns(45);
+
+      await expect(
+        lendingMarketControllerProxy.initializeLendingMarket(
+          targetCurrency,
+          genesisDate,
+          INITIAL_COMPOUND_FACTOR,
+          ORDER_FEE_RATE,
+          CIRCUIT_BREAKER_LIMIT_RANGE,
+          MIN_DEBT_UNIT_PRICE,
+        ),
+      ).revertedWith(`TooManyTokenDecimals("${mockERC20.address}", 45)`);
     });
 
     it('Get genesisDate', async () => {

--- a/test/unit/lending-market-controller/rotations.test.ts
+++ b/test/unit/lending-market-controller/rotations.test.ts
@@ -807,11 +807,23 @@ describe('LendingMarketController - Rotations', () => {
     });
 
     it('Fail to rotate order books due to no order book', async () => {
+      const targetCurrency = ethers.utils.formatBytes32String('NoOrderBook');
+      await lendingMarketControllerProxy.migrateLendingMarket(
+        targetCurrency,
+        0,
+      );
+
+      await expect(
+        lendingMarketControllerProxy.rotateOrderBooks(targetCurrency),
+      ).revertedWith('NotEnoughOrderBooks');
+    });
+
+    it('Fail to rotate order books due to no zc token', async () => {
       await expect(
         lendingMarketControllerProxy.rotateOrderBooks(
-          ethers.utils.formatBytes32String('Test'),
+          ethers.utils.formatBytes32String('NoZcToken'),
         ),
-      ).revertedWith('NotEnoughOrderBooks');
+      ).revertedWith('ZcTokenIsZero');
     });
   });
 

--- a/test/unit/lending-market-controller/tokenization.test.ts
+++ b/test/unit/lending-market-controller/tokenization.test.ts
@@ -251,7 +251,7 @@ describe('LendingMarketController - Tokenization', () => {
 
     it('Create a new zc token manually', async () => {
       await expect(
-        lendingMarketControllerProxy.createZCToken(targetCurrency, 0),
+        lendingMarketControllerProxy.migrateLendingMarket(targetCurrency, 0),
       )
         .to.emit(lendingMarketOperationLogic, 'ZCTokenCreated')
         .withArgs(
@@ -264,25 +264,28 @@ describe('LendingMarketController - Tokenization', () => {
         );
     });
 
-    it('Fail to create a new zc token manually if it already exists', async () => {
-      await lendingMarketControllerProxy.createZCToken(targetCurrency, 0);
+    it('Fail to migrate a lending market manually if it already exists', async () => {
+      await lendingMarketControllerProxy.migrateLendingMarket(
+        targetCurrency,
+        0,
+      );
 
       await expect(
-        lendingMarketControllerProxy.createZCToken(targetCurrency, 0),
+        lendingMarketControllerProxy.migrateLendingMarket(targetCurrency, 0),
       ).to.be.revertedWith('AlreadyZCTokenExists');
     });
 
-    it('Fail to create a new zc token manually if the maturity is invalid', async () => {
+    it('Fail to migrate a lending market manually if the maturity is invalid', async () => {
       await expect(
-        lendingMarketControllerProxy.createZCToken(targetCurrency, 1),
+        lendingMarketControllerProxy.migrateLendingMarket(targetCurrency, 1),
       ).to.be.revertedWith('InvalidMaturity');
     });
 
-    it('Fail to create a new zc token manually if the caller is not owner', async () => {
+    it('Fail to migrate a lending market manually if the caller is not owner', async () => {
       await expect(
         lendingMarketControllerProxy
           .connect(alice)
-          .createZCToken(targetCurrency, 0),
+          .migrateLendingMarket(targetCurrency, 0),
       ).to.be.revertedWith('Ownable: caller is not the owner');
     });
   });
@@ -660,7 +663,7 @@ describe('LendingMarketController - Tokenization', () => {
       );
 
       const estimatedAmount = calculateFutureValue(value, 8000)
-        .mul(BigNumber.from(10).pow(36))
+        .mul(BigNumber.from(10).pow(38))
         .div(autoRollLog.lendingCompoundFactor);
 
       const withdrawableAmountAfter =
@@ -755,7 +758,7 @@ describe('LendingMarketController - Tokenization', () => {
         totalUnusedCollateral.mul(PCT_DIGIT).div(HAIRCUT),
         8000,
       )
-        .mul(BigNumber.from(10).pow(36))
+        .mul(BigNumber.from(10).pow(38))
         .div(compoundFactor);
       const withdrawableAmount =
         await lendingMarketControllerProxy.getWithdrawableZCTokenAmount(
@@ -1095,7 +1098,7 @@ describe('LendingMarketController - Tokenization', () => {
         maturities[0],
       );
       const estimatedAmount = calculateFutureValue(value, 8000)
-        .mul(BigNumber.from(10).pow(36))
+        .mul(BigNumber.from(10).pow(38))
         .div(autoRollLog.lendingCompoundFactor);
       const currentBalance = await zcToken.balanceOf(alice.address);
 


### PR DESCRIPTION
- Change the ZC Token decimas from 36 to 24
- Add a migration function for lending markets.